### PR TITLE
Fix 'Undefined array key "customerPrice"'

### DIFF
--- a/src/CommunityStore/Cart/Cart.php
+++ b/src/CommunityStore/Cart/Cart.php
@@ -513,7 +513,7 @@ class Cart
 
                         if ($attsmatch) {
                             // test for a customer entered price, treat a different item if different amount
-                            if ($cartItem['product']['customerPrice']) {
+                            if (!empty($cartItem['product']['customerPrice'])) {
                                 if ($cartItem['product']['customerPrice'] != $cart['product']['customerPrice']) {
                                     $attsmatch = false;
                                 }


### PR DESCRIPTION
This PR fixes the warning `Fix 'Undefined array key "customerPrice"` when adding a product to the cart