### PR TITLE
export-ignore development stuff

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+/docs/ export-ignore
+/package.json export-ignore
+/README.md export-ignore
+/yarn.lock export-ignore
+/.* export-ignore


### PR DESCRIPTION
When downloading the .zip file from the [releases page](https://github.com/concretecms-community-store/community_store/releases), we have a ton of files that are only useful for development.

What about excluding them from the .zip files that are automatically generated by git (and github)?

If people still want the full repository contents, they can still do a `git clone`