### PR TITLE
Use $app->make() to create payment method controller instances

### DIFF
--- a/src/CommunityStore/Payment/Method.php
+++ b/src/CommunityStore/Payment/Method.php
@@ -199,12 +199,9 @@ class Method extends Controller
 
         $th = $app->make("helper/text");
         $pkg = $app->make('Concrete\Core\Package\PackageService')->getByID($this->pkgID);
-
         $namespace = "Concrete\\Package\\" . $th->camelcase($pkg->getPackageHandle()) . "\\Src\\CommunityStore\\Payment\\Methods\\" . $th->camelcase($this->pmHandle);
-
         $className = $th->camelcase($this->pmHandle) . "PaymentMethod";
-        $namespace = $namespace . '\\' . $className;
-        $this->methodController = new $namespace();
+        $this->methodController = $app->make($namespace . '\\' . $className);
     }
 
     public function getMethodController()


### PR DESCRIPTION
What about using `$app->make()` instead of `new` to create instances of the controllers of payment methods?

That way, we could use dependency injection to initialize the controllers...