### PR TITLE
Add GitHub Action to attach .zip file to releases

### DIFF
--- a/.github/workflows/create-release-attachment.yml
+++ b/.github/workflows/create-release-attachment.yml
@@ -1,0 +1,52 @@
+on:
+  release:
+    types:
+      - published
+
+env:
+  PACKAGE_HANDLE: community_store
+
+jobs:
+  create-release-attachment:
+    name: Create Release Attachment
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+            php-version: '7.4'
+            tools: composer:v2
+            coverage: none
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Prepare working directory
+        run: |
+            rm -rf /tmp/$PACKAGE_HANDLE /tmp/$PACKAGE_HANDLE.zip
+            mkdir /tmp/$PACKAGE_HANDLE
+      - name: Export repository
+        run: git archive --format=tar HEAD | tar x -C /tmp/$PACKAGE_HANDLE
+      - name: Install composer dependencies
+        run: composer update --prefer-dist --no-dev --no-progress --optimize-autoloader --ansi --no-interaction --no-cache --working-dir=/tmp/$PACKAGE_HANDLE
+      - name: Check if composer directory is needed
+        run: |
+            if [ -z "$(ls -l /tmp/$PACKAGE_HANDLE/vendor/ | grep -E ^d | grep -vE ' composer$')" ]; then
+                echo 'No composer dependencies found: deleting the vendor directory'
+                rm -rf /tmp/$PACKAGE_HANDLE/vendor
+            else
+                echo 'No composer dependencies found: keeping the vendor directory'
+            fi
+      - name: Copying additional files
+        run: >
+          cp -t /tmp/$PACKAGE_HANDLE
+          README.md
+      - name: Remove unneeded files
+        run: >
+          rm
+          /tmp/$PACKAGE_HANDLE/composer.json
+          /tmp/$PACKAGE_HANDLE/composer.lock
+      - name: Creating final ZIP archive
+        run: (cd /tmp && zip -r $PACKAGE_HANDLE.zip $PACKAGE_HANDLE)
+      - name: Attach ZIP archive to release
+        env:
+          GH_TOKEN: ${{ secrets.ATTACH_ASSETS_SECRET }}
+        run: gh release upload "$GITHUB_REF_NAME" /tmp/$PACKAGE_HANDLE.zip


### PR DESCRIPTION
What about adding a GitHub Action that automatically creates the .zip archive to be attached to GitHub Releases?

If you want to see it in action: see [this execution](https://github.com/mlocati/community_store/actions/runs/5231721255) that automatically attached `community_store.zip` when I created [this sample release](https://github.com/mlocati/community_store/releases/tag/100).

PS: in order to grant the permission to attach files to releases, you need to:

1. create a Personal Access Token. For better security, you can create a "Fine-grained Personal Access Token" at https://github.com/settings/tokens?type=beta limiting its access to the `concretecms-community-store/community_store repository` and selecting only this permission:  
![immagine](https://github.com/concretecms-community-store/community_store/assets/928116/9f643e5a-12e6-4658-94e6-9528d8864401)
2. [create a secret in the `concretecms-community-store/community_store`])https://github.com/concretecms-community-store/community_store/settings/secrets/actions) named `ATTACH_ASSETS_SECRET` with the value of the above personal access token
