### PR TITLE
Fix product list block on PHP 8

### DIFF
--- a/blocks/community_product_list/view.php
+++ b/blocks/community_product_list/view.php
@@ -20,6 +20,10 @@ $c = \Concrete\Core\Page\Page::getCurrentPage();
 
 $columnClass = 'col-md-12';
 
+if (empty($productsPerRow)) {
+    $productsPerRow = 1;
+}
+
 if ($productsPerRow == 2) {
     $columnClass = 'col-md-6 col-sm-6 col-xs-12';
 }
@@ -34,10 +38,6 @@ if ($productsPerRow == 4) {
 
 if ($productsPerRow == 6) {
     $columnClass = 'col-md-2 col-sm-6 col-xs-12';
-}
-
-if (!$productsPerRow) {
-    $productsPerRow = 1;
 }
 
 $activeclass = '';


### PR DESCRIPTION
If we choose to display the products "by line", we have an "undefined variable" error: let's fix it.