### PR TITLE
Add support for external payment methods that use GET instead of POST

### DIFF
--- a/controllers/single_page/checkout.php
+++ b/controllers/single_page/checkout.php
@@ -371,9 +371,13 @@ class Checkout extends PageController
         if ($ajax->isAjaxRequest($this->request)){
             return new JsonResponse(['OK'=>1]);
         }
-
+        $pmController = $pm->getMethodController();
+        $action = $pmController->getAction();
+        if ($pmController->isExternalActionGET()) {
+            return $this->buildRedirect($action);
+        }
         $this->set('pm', $pm);
-        $this->set('action', $pm->getMethodController()->getAction());
+        $this->set('action', $action);
     }
 
     public function updater()

--- a/src/CommunityStore/Payment/Method.php
+++ b/src/CommunityStore/Payment/Method.php
@@ -358,6 +358,19 @@ class Method extends Controller
         return false;
     }
 
+    /**
+     * For external payment methods only.
+     *
+     * If the external URL should be invoked with a POST (whose body is specified in the redirectForm() method and redirect_form element), return false.
+     * If the external URL should be invoked with GET, return true.
+     * 
+     * @return bool
+     */
+    public function isExternalActionGET()
+    {
+        return false;
+    }
+
     public function markPaid()
     {
         return true;


### PR DESCRIPTION
The [new payment method](https://github.com/concretecms-community-store/community_store/issues/768) I'm developing, requires invoking an external URL via GET instead of [POST](https://github.com/concretecms-community-store/community_store/blob/v2.5.1/single_pages/checkout.php#L572).

With this change, payment method controllers can override the new `isExternalActionGET()` method: if it returns `true`, the URL returned by the `getAction()` method will be called via GET instead of POST.