### PR TITLE
Fix "Undefined variable $showQuantity" in elements/product_modal.php:50

### DIFF
--- a/elements/product_modal.php
+++ b/elements/product_modal.php
@@ -47,7 +47,7 @@ $token = $app->make('token');
             <?php if ('all' != Config::get('community_store.shoppingDisabled')) {
                 ?>
             <div class="store-product-modal-quantity form-group">
-                <?php if ($product->allowQuantity() && $showQuantity) {
+                <?php if ($product->allowQuantity() && !empty($showQuantity)) {
                     ?>
                     <div class="store-product-quantity form-group">
                         <label class="store-product-option-group-label"><?= t('Quantity'); ?></label>


### PR DESCRIPTION
I have this entry in my server logs:

```
Exception Occurred: packages/community_store/elements/product_modal.php:50
Undefined variable $showQuantity
```

Let's fix this issue