### PR TITLE
Add pvID to product variations sort

### DIFF
--- a/src/CommunityStore/Product/Product.php
+++ b/src/CommunityStore/Product/Product.php
@@ -418,7 +418,7 @@ class Product
 
     /**
      * @ORM\OneToMany(targetEntity="Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductVariation\ProductVariation", mappedBy="product",cascade={"persist"}))
-     * @ORM\OrderBy({"pvSort" = "ASC"})
+     * @ORM\OrderBy({"pvSort" = "ASC", "pvID" = "ASC"})
      */
     protected $variations;
 


### PR DESCRIPTION
Usually, the database field `CommunityStoreProductVariations.pvSort` is unique for the records with the same `CommunityStoreProductVariations.pID`.

But in case something goes wrong, we may end up having a duplicated `pvSort`.
So, what about adding an additional sorting criteria? That way, we are sure that the order or product variations is always well defined.