### PR TITLE
Use GitHub Action to attach ZIP to GitHub Releases

### DIFF
--- a/.github/workflows/create-release-attachment.yml
+++ b/.github/workflows/create-release-attachment.yml
@@ -1,52 +1,30 @@
+name: Attach ZIP to GitHub Release
+
 on:
   release:
     types:
       - published
 
-env:
-  PACKAGE_HANDLE: community_store
-
 jobs:
-  create-release-attachment:
-    name: Create Release Attachment
+  attach-zip:
+    name: Attach ZIP to release
     runs-on: ubuntu-latest
     steps:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-            php-version: '7.4'
-            tools: composer:v2
-            coverage: none
+          php-version: '7.4'
+          tools: composer:v2
+          coverage: none
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Prepare working directory
-        run: |
-            rm -rf /tmp/$PACKAGE_HANDLE /tmp/$PACKAGE_HANDLE.zip
-            mkdir /tmp/$PACKAGE_HANDLE
-      - name: Export repository
-        run: git archive --format=tar HEAD | tar x -C /tmp/$PACKAGE_HANDLE
-      - name: Install composer dependencies
-        run: composer update --prefer-dist --no-dev --no-progress --optimize-autoloader --ansi --no-interaction --no-cache --working-dir=/tmp/$PACKAGE_HANDLE
-      - name: Check if composer directory is needed
-        run: |
-            if [ -z "$(ls -l /tmp/$PACKAGE_HANDLE/vendor/ | grep -E ^d | grep -vE ' composer$')" ]; then
-                echo 'No composer dependencies found: deleting the vendor directory'
-                rm -rf /tmp/$PACKAGE_HANDLE/vendor
-            else
-                echo 'No composer dependencies found: keeping the vendor directory'
-            fi
-      - name: Copying additional files
-        run: >
-          cp -t /tmp/$PACKAGE_HANDLE
-          README.md
-      - name: Remove unneeded files
-        run: >
-          rm
-          /tmp/$PACKAGE_HANDLE/composer.json
-          /tmp/$PACKAGE_HANDLE/composer.lock
-      - name: Creating final ZIP archive
-        run: (cd /tmp && zip -r $PACKAGE_HANDLE.zip $PACKAGE_HANDLE)
-      - name: Attach ZIP archive to release
+      - name: Create and attach ZIP
+        uses: concrete5-community/gh-package-release-attach@main
         env:
-          GH_TOKEN: ${{ secrets.ATTACH_ASSETS_SECRET }}
-        run: gh release upload "$GITHUB_REF_NAME" /tmp/$PACKAGE_HANDLE.zip
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          remove-files: |
+            composer.json
+            composer.lock
+          keep-files: |
+            README.md


### PR DESCRIPTION
Instead of copying the same (rather complex) code to my repositories, I've created [a GitHub Action](https://github.com/concrete5-community/gh-package-release-attach) that automatically creates the package ZIP file and attach it to GitHub releases.

PS: the `ATTACH_ASSETS_SECRET` secret (and the related personal access token) is no more needed (but please configure `GITHUB_TOKEN` as described in the [requirements](https://github.com/concrete5-community/gh-package-release-attach#requirements) section).

I've already added this action to https://github.com/concretecms-community-store/community_store_bcc_payway (see [the action](https://github.com/concretecms-community-store/community_store_bcc_payway/actions/runs/5321489824) and [the release](https://github.com/concretecms-community-store/community_store_bcc_payway/releases/tag/1.0.2)).