### PR TITLE
Fix accessing undef variable $variationLookup in product_modal

### DIFF
--- a/elements/product_modal.php
+++ b/elements/product_modal.php
@@ -120,7 +120,7 @@ $token = $app->make('token');
                             $outOfStock = false;
                             foreach ($optionItems as $optionItem) {
                                 if (!$optionItem->isHidden()) {
-                                    $variation = $variationLookup[$optionItem->getID()];
+                                    $variation = isset($variationLookup[$optionItem->getID()]) ? $variationLookup[$optionItem->getID()] : null;
                                     if (!empty($variation)) {
                                         $firstAvailableVariation = (!$firstAvailableVariation && $variation->isSellable()) ? $variation : $firstAvailableVariation;
                                         $disabled = $variation->isSellable() ? '' : 'disabled="disabled" ';


### PR DESCRIPTION
I don't know when this occurs, but I have the following error in the logs:

```
Exception Occurred:
packages/community_store/elements/product_modal.php:123]:
Undefined variable $variationLookup
```

The easy fix is cffdfbd7e55bc4b3ede8023e9ab76d1a39ba7dd7 (included in this PR), but I'm wondering if instead we should move the definition of `$variationLookup` currently at line 205 before line 123