### PR TITLE
Don't use t() and ucwords() for order status

### DIFF
--- a/single_pages/dashboard/store/orders.php
+++ b/single_pages/dashboard/store/orders.php
@@ -752,7 +752,7 @@ use \Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Price;
 
                         ?>
                     </td>
-                    <td><?= t(ucwords($order->getStatus())) ?></td>
+                    <td><?= $order->getStatus() ?></td>
                     <td>
                         <div class="btn-group" style="width:100px">
                             <a class="btn btn-primary btn-sm"

--- a/single_pages/dashboard/store/overview.php
+++ b/single_pages/dashboard/store/overview.php
@@ -291,7 +291,7 @@ if ($taxCalc == 'extract') {
 
                             ?>
                         </td>
-                        <td><?= t(ucwords($order->getStatus())) ?></td>
+                        <td><?= $order->getStatus() ?></td>
                         <td>
                             <div class="btn-group" style="width:100px">
                                 <a class="btn btn-primary btn-sm"


### PR DESCRIPTION
Here in Italy we don't use Title Case, it seems really ugly to us (we use capital letters only at the beginning of sentences). So, what about avoiding `ucwords` calls? (and I'm pretty sure it doesn't work very well with multibyte characters - we should use `mb_convert_case` instead)

Furthermore, order statuses are already translated, so I think we don't need `t()` calls.