### PR TITLE
Display original price when discounts are applied

### DIFF
--- a/blocks/community_product/view.php
+++ b/blocks/community_product/view.php
@@ -82,9 +82,12 @@ if (isset($product) && is_object($product) && $product->isActive()) {
                     ?>
 
                     <?php if ($showProductPrice && !$product->allowCustomerPrice()) {
-                        $salePrice = $product->getSalePrice();
-                        $price = $product->getPrice();
-                        $activePrice = ($salePrice ? $salePrice : $price ) - $product->getPriceAdjustment($product->getDiscountRules());
+                        $salePrice = $product->getSalePrice() ?: $product->getPrice();
+                        $price = $product->getPrice(1, true);
+                        if ($salePrice == $price) {
+                            $salePrice = false;
+                        }
+                        $activePrice = ($salePrice ?: $price) - $product->getPriceAdjustment($product->getDiscountRules());
 
                         if ($isWholesale) {
                             $msrp = $product->getFormattedOriginalPrice();
@@ -107,7 +110,7 @@ if (isset($product) && is_object($product) && $product->isActive()) {
                             } else {
 
                                 if (isset($salePrice) && "" != $salePrice) {
-                                    $formattedSalePrice = $product->getFormattedSalePrice();
+                                    $formattedSalePrice = $product->getFormattedSalePrice() ?: $product->getFormattedPrice(1, false);
                                     $formattedOriginalPrice = $product->getFormattedOriginalPrice();
                                     echo t('On Sale') . ': <span class="store-sale-price">' . $formattedSalePrice . '</span>';
                                     echo '&nbsp;' . t('was') . '&nbsp;';

--- a/blocks/community_product_list/view.php
+++ b/blocks/community_product_list/view.php
@@ -172,15 +172,17 @@ $activeclass = '';
                     } ?>
 
                     <?php if ($showPrice && !$product->allowCustomerPrice()) {
-                        $salePrice = $product->getSalePrice();
-                        $price = $product->getPrice();
-                        $activePrice = ($salePrice ? $salePrice : $price ) - $product->getPriceAdjustment($product->getDiscountRules());
+                        $salePrice = $product->getSalePrice() ?: $product->getPrice();
+                        $price = $product->getPrice(1, true);
+                        if ($salePrice == $price) {
+                            $salePrice = false;
+                        }
+                        $activePrice = ($salePrice ?: $price) - $product->getPriceAdjustment($product->getDiscountRules());
                         ?>
                         <p class="store-product-price store-product-list-price" data-price="<?= $activePrice; ?>" data-original-price="<?= ($salePrice ? $price : ''); ?>" >
                             <?php
-                            $salePrice = $product->getSalePrice();
                             if (isset($salePrice) && "" != $salePrice) {
-                                $formattedSalePrice = $product->getFormattedSalePrice();
+                                $formattedSalePrice = $product->getFormattedSalePrice() ?: $product->getFormattedPrice(1, false);
                                 $formattedOriginalPrice = $product->getFormattedOriginalPrice();
                                 echo '<span class="store-sale-price">' . $formattedSalePrice . '</span>';
                                 echo '&nbsp;' . t('was') . '&nbsp;' . '<span class="store-original-price">' . $formattedOriginalPrice . '</span>';


### PR DESCRIPTION
Let's assume we have:

1. a product group named "10% off"
2. a discount of 10% for all the product in the "10% off" group

| Product | Before | After |
|:---|:---:|:---:|
| Price : 100<br />Sale price: empty<br />Groups: none | ![immagine](https://github.com/concretecms-community-store/community_store/assets/928116/ee71da60-625f-4759-bdd0-9853a4745254) | ![immagine](https://github.com/concretecms-community-store/community_store/assets/928116/9a7905b0-e370-4239-b597-944491b71f19) |
| Price : 100<br />Sale price: 90<br />Groups: none | ![immagine](https://github.com/concretecms-community-store/community_store/assets/928116/8d5d7df2-514a-4fc6-86cf-624692149718) | ![immagine](https://github.com/concretecms-community-store/community_store/assets/928116/aaa33724-29c8-4d37-90d1-56e0c4febdab) |
| Price : 100<br />Sale price: empty<br />Groups: 10% off | ![immagine](https://github.com/concretecms-community-store/community_store/assets/928116/1d21a903-c354-474a-ad69-370c33adbfb4) | ![immagine](https://github.com/concretecms-community-store/community_store/assets/928116/10cfd108-08e7-4101-9d27-7eb4ef3cc47e) |

See the difference in the Product C.

Fix #794