### PR TITLE
Add breadcrumbs

### DIFF
--- a/controllers/single_page/dashboard/store/discounts.php
+++ b/controllers/single_page/dashboard/store/discounts.php
@@ -3,6 +3,7 @@ namespace Concrete\Package\CommunityStore\Controller\SinglePage\Dashboard\Store;
 
 use Concrete\Core\Filesystem\ElementManager;
 use Concrete\Core\Http\Request;
+use Concrete\Core\Navigation\Item\Item;
 use Concrete\Core\Routing\Redirect;
 use Concrete\Core\User\Group\GroupList;
 use Concrete\Core\Support\Facade\Session;
@@ -74,12 +75,19 @@ class Discounts extends DashboardPageController
         $this->set('selectedproductgroups', []);
         $this->set('selectedusergroups', []);
         $this->set('discountRule', false);
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $breacrumb->add(new Item('#', t('Add Discount Rule')));
+        }
     }
 
     public function edit($drID)
     {
         $this->requireAsset('selectize');
         $discountRule = DiscountRule::getByID($drID);
+        if ($discountRule === null) {
+            return $this->buildRedirect('/dashboard/store/discounts');
+        }
 
         $this->set('discountRule', $discountRule);
         $this->set('pageTitle', t('Edit Discount Rule'));
@@ -109,6 +117,10 @@ class Discounts extends DashboardPageController
         $this->set('selectedproductgroups', $discountRule->getProductGroups());
         $this->set('selectedusergroups', $discountRule->getUserGroups());
         $this->set('usergroups', $usergrouparray);
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $breacrumb->add(new Item('#', $discountRule->getName()));
+        }
     }
 
     public function codes($drID)

--- a/controllers/single_page/dashboard/store/manufacturers.php
+++ b/controllers/single_page/dashboard/store/manufacturers.php
@@ -5,6 +5,7 @@ namespace Concrete\Package\CommunityStore\Controller\SinglePage\Dashboard\Store;
 use Concrete\Core\Http\Request;
 use Concrete\Core\Routing\Redirect;
 use Concrete\Core\Http\ResponseFactory;
+use Concrete\Core\Navigation\Item\Item;
 use Concrete\Core\Support\Facade\Url;
 use \Concrete\Core\Page\Controller\PageController;
 use Concrete\Core\Support\Facade\Config;
@@ -42,13 +43,24 @@ class Manufacturers extends DashboardPageController
         $this->set('pageTitle', t('Add Manufacturer'));
         $manufacturer = new Manufacturer();
         $this->set('manufacturer', $manufacturer);
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $breacrumb->add(new Item('#', t('Add Manufacturer')));
+        }
     }
 
     public function edit($id = 0)
     {
-        $this->set('pageTitle', t('Edit Manufacturer'));
         $manufacturer = Manufacturer::getByID($id);
+        if ($manufacturer === null) {
+            return $this->buildRedirect('/dashboard/store/manufacturers');
+        }
+        $this->set('pageTitle', t('Edit Manufacturer'));
         $this->set('manufacturer', $manufacturer);
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $breacrumb->add(new Item('#', $manufacturer->getName()));
+        }
     }
 
     public function submit()

--- a/controllers/single_page/dashboard/store/orders.php
+++ b/controllers/single_page/dashboard/store/orders.php
@@ -5,6 +5,7 @@ use Concrete\Core\Filesystem\ElementManager;
 use Concrete\Core\User\User;
 use Concrete\Core\View\View;
 use Concrete\Core\Http\Request;
+use Concrete\Core\Navigation\Item\Item;
 use Concrete\Core\Routing\Redirect;
 use Concrete\Core\Support\Facade\Config;
 use Concrete\Core\Search\Pagination\PaginationFactory;
@@ -126,6 +127,10 @@ class Orders extends DashboardPageController
         $this->set('showFiles', class_exists('Concrete\Package\CommunityStoreFileUploads\Src\CommunityStore\Order\OrderItemFile'));
 
         $this->set('pageTitle', t("Order #") . $order->getOrderID());
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $breacrumb->add(new Item('#', t("Order #") . $order->getOrderID()));
+        }
     }
 
     public function updatestatus($oID)

--- a/controllers/single_page/dashboard/store/orders/attributes.php
+++ b/controllers/single_page/dashboard/store/orders/attributes.php
@@ -3,6 +3,7 @@ namespace Concrete\Package\CommunityStore\Controller\SinglePage\Dashboard\Store\
 
 use Concrete\Core\Attribute\Key\Category;
 use Concrete\Core\Attribute\Type;
+use Concrete\Core\Navigation\Item\Item;
 use Concrete\Core\Page\Controller\DashboardAttributesPageController;
 use Concrete\Core\Support\Facade\Url;
 
@@ -23,9 +24,16 @@ class Attributes extends DashboardAttributesPageController
         $this->requireAsset('selectize');
 
         $key = $this->getCategoryObject()->getController()->getByID($akID);
+        if ($key === null) {
+            return $this->buildRedirect('/dashboard/store/orders/attributes');
+        }
         $this->renderEdit($key,
             Url::to('/dashboard/store/orders/attributes', 'view')
         );
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $breacrumb->add(new Item('#', $key->getAttributeKeyDisplayName('text')));
+        }
     }
 
     public function update($akID = null)
@@ -39,11 +47,18 @@ class Attributes extends DashboardAttributesPageController
 
     public function select_type($type = null)
     {
-        $this->requireAsset('selectize');
         $type = Type::getByID($type);
+        if ($type === null) {
+            return $this->buildRedirect('/dashboard/store/orders/attributes');
+        }
+        $this->requireAsset('selectize');
         $this->renderAdd($type,
             Url::to('/dashboard/store/orders/attributes', 'view')
         );
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $breacrumb->add(new Item('#', t('Add Attribute')));
+        }
     }
 
     public function add($type = null)

--- a/controllers/single_page/dashboard/store/products.php
+++ b/controllers/single_page/dashboard/store/products.php
@@ -5,6 +5,7 @@ use Concrete\Core\File\Search\Menu\MenuFactory;
 use Concrete\Core\Filesystem\ElementManager;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Http\Request;
+use Concrete\Core\Navigation\Item\Item;
 use Concrete\Core\Routing\Redirect;
 use Concrete\Core\User\Group\GroupList;
 use Concrete\Core\Support\Facade\Config;
@@ -178,6 +179,11 @@ class Products extends DashboardSitePageController
             $productType = ProductType::getByID($typeID);
         }
         $this->set('productType', $productType);
+
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $breacrumb->add(new Item('#', t('Add Product')));
+        }
     }
 
     public function edit($pID)
@@ -330,6 +336,11 @@ class Products extends DashboardSitePageController
 
         $this->set('keywordsSearch', Session::get('communitystore.dashboard.products.keywords'));
         $this->set('groupSearch', Session::get('communitystore.dashboard.products.group'));
+
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $breacrumb->add(new Item('#', $product->getName()));
+        }
     }
 
     public function generate($pID, $templateID = null)
@@ -355,6 +366,13 @@ class Products extends DashboardSitePageController
 
         $this->set('pageTitle', t('Duplicate Product'));
         $this->set('product', $product);
+        $newProductName = $product->getName() . ' ' . t('(Copy)');
+        $this->set('newProductName', $newProductName);
+
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $breacrumb->add(new Item('#', $newProductName));
+        }
     }
 
     public function delete($pID)

--- a/controllers/single_page/dashboard/store/products/attributes.php
+++ b/controllers/single_page/dashboard/store/products/attributes.php
@@ -4,6 +4,7 @@ namespace Concrete\Package\CommunityStore\Controller\SinglePage\Dashboard\Store\
 use Concrete\Core\Attribute\Type;
 use Concrete\Core\Support\Facade\Url;
 use Concrete\Core\Attribute\Key\Category;
+use Concrete\Core\Navigation\Item\Item;
 use Concrete\Core\Page\Controller\DashboardAttributesPageController;
 
 class Attributes extends DashboardAttributesPageController
@@ -21,9 +22,16 @@ class Attributes extends DashboardAttributesPageController
     public function edit($akID = null)
     {
         $key = $this->getCategoryObject()->getController()->getByID($akID);
+        if ($key === null) {
+            return $this->buildRedirect('/dashboard/store/products/attributes');
+        }
         $this->renderEdit($key,
             Url::to('/dashboard/store/products/attributes', 'view')
         );
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $breacrumb->add(new Item('#', $key->getAttributeKeyDisplayName('text')));
+        }
     }
 
     public function update($akID = null)
@@ -38,9 +46,16 @@ class Attributes extends DashboardAttributesPageController
     public function select_type($type = null)
     {
         $type = Type::getByID($type);
+        if ($type === null) {
+            return $this->buildRedirect('/dashboard/store/products/attributes');
+        }
         $this->renderAdd($type,
             Url::to('/dashboard/store/products/attributes', 'view')
         );
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $breacrumb->add(new Item('#', t('Add Attribute')));
+        }
     }
 
     public function add($type = null)

--- a/controllers/single_page/dashboard/store/products/categories.php
+++ b/controllers/single_page/dashboard/store/products/categories.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Package\CommunityStore\Controller\SinglePage\Dashboard\Store\Products;
 
+use Concrete\Core\Navigation\Item\Item;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Routing\Redirect;
 use Concrete\Core\Page\Controller\DashboardPageController;
@@ -22,7 +23,7 @@ class Categories extends DashboardPageController
 
         $page = Page::getByID($cID);
 
-        if (!$page) {
+        if (!$page || $page->isError()) {
             return Redirect::to('/dashboard/store/products/categories');
         }
 
@@ -35,14 +36,16 @@ class Categories extends DashboardPageController
         $this->set('page', $page);
         $this->set('cID', $cID);
         $this->set('pageTitle', t('Manage Category: ' . $page->getCollectionName()));
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $breacrumb->add(new Item('#', $page->getCollectionName()));
+        }
     }
 
     public function save($cID)
     {
         if ($this->request->request->all() && $this->token->validate('community_store')) {
             $data = $this->request->request->all();
-
-            $count = 0;
 
             $productLocations = ProductLocation::getProductsForLocation($cID);
 

--- a/controllers/single_page/dashboard/store/products/groups.php
+++ b/controllers/single_page/dashboard/store/products/groups.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Package\CommunityStore\Controller\SinglePage\Dashboard\Store\Products;
 
+use Concrete\Core\Navigation\Item\Item;
 use Concrete\Core\Routing\Redirect;
 use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductGroup;
@@ -47,6 +48,10 @@ class Groups extends DashboardPageController
                 return Redirect::to('/dashboard/store/products/groups');
             }
         }
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $breacrumb->add(new Item('#', t('Add Product Group')));
+        }
     }
 
     public function edit($gID)
@@ -88,6 +93,10 @@ class Groups extends DashboardPageController
         }
 
         $this->set('group', $group);
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $breacrumb->add(new Item('#', $group->getGroupName()));
+        }
     }
 
     public function validateGroup($args)

--- a/controllers/single_page/dashboard/store/products/types.php
+++ b/controllers/single_page/dashboard/store/products/types.php
@@ -2,11 +2,13 @@
 namespace Concrete\Package\CommunityStore\Controller\SinglePage\Dashboard\Store\Products;
 
 use Concrete\Core\Attribute\Key\Key as AttributeKey;
+use Concrete\Core\Navigation\Item\Item;
 use Concrete\Core\Page\Type\Composer\Control\CollectionAttributeControl;
 use Concrete\Core\Routing\Redirect;
 use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Support\Facade\DatabaseORM as dbORM;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 use Concrete\Package\CommunityStore\Attribute\ProductKey;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductList;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductType\ProductType;
@@ -44,17 +46,19 @@ class Types extends DashboardPageController
                 return Redirect::to('/dashboard/store/products/types');
             }
         }
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $breacrumb->add(new Item('#', t('Add Product Type')));
+        }
     }
 
     public function attributes($ptID)
     {
         $type = ProductType::getByID($ptID);
-        $this->set('pageTitle', t('Manage Attributes for %s', $type->getTypeName()));
-
-
         if (!$type) {
             return Redirect::to('/dashboard/store/products/types');
         }
+        $this->set('pageTitle', t('Manage Attributes for %s', $type->getTypeName()));
 
         $this->set('type', $type);
         $this->render('/dashboard/store/products/types/attributes');
@@ -63,7 +67,12 @@ class Types extends DashboardPageController
         $keys = AttributeKey::getAttributeKeyList('store_product');
 
         $this->set('keys', $keys);
-
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $rm = $this->app->make(ResolverManagerInterface::class);
+            $breacrumb->add(new Item($rm->resolve(['/dashboard/store/products/types/edit', $type->getTypeID()]), $type->getTypeName()));
+            $breacrumb->add(new Item('#', t('Attributes')));
+        }
     }
 
     public function edit($ptID)
@@ -91,6 +100,10 @@ class Types extends DashboardPageController
         }
 
         $this->set('type', $type);
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $breacrumb->add(new Item('#', $type->getTypeName()));
+        }
     }
 
     public function validateType($args)

--- a/controllers/single_page/dashboard/store/reports/products.php
+++ b/controllers/single_page/dashboard/store/reports/products.php
@@ -2,6 +2,7 @@
 namespace Concrete\Package\CommunityStore\Controller\SinglePage\Dashboard\Store\Reports;
 
 use Concrete\Core\Http\Request;
+use Concrete\Core\Navigation\Item\Item;
 use Concrete\Core\Search\Pagination\PaginationFactory;
 use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product;
@@ -186,6 +187,10 @@ class Products extends DashboardPageController
         $this->set('products', $allproducts);
         $this->set('pageTitle', 'Product Price/Shipping Sheet');
         $this->render('/dashboard/store/reports/products/sheet');
+        if (method_exists($this, 'createBreadcrumb')) {
+            $this->setBreadcrumb($breacrumb = $this->getBreadcrumb() ?: $this->createBreadcrumb());
+            $breacrumb->add(new Item('#', t('Product Price/Shipping Sheet')));
+        }
     }
 
 }

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -2274,12 +2274,17 @@ if (version_compare($version, '9.0', '<')) {
 
 <?php } ?>
 
-<?php if ($controller->getAction() == 'duplicate') { ?>
+<?php
+if ($controller->getAction() == 'duplicate') {
+    /**
+     * @var string $newProductName
+     */
+    ?>
     <form method="post" action="<?= $view->action('duplicate', $product->getID()) ?>">
         <?= $token->output('community_store'); ?>
         <div class="form-group">
             <?= $form->label('newName', t("New Product Name")); ?>
-            <?= $form->text('newName', $product->getName() . ' ' . t('(Copy)')); ?>
+            <?= $form->text('newName', $newProductName); ?>
         </div>
 
         <div class="form-group">


### PR DESCRIPTION
What about adding breadcrumbs to dashboard pages?

For example, turns this

![immagine](https://github.com/concretecms-community-store/community_store/assets/928116/970092cc-3bee-45a8-9039-11f758501365)

into this:

![immagine](https://github.com/concretecms-community-store/community_store/assets/928116/567a37ab-0317-46df-be0b-9eba95f2c241)
