### PR TITLE
Fix "price" itemprop

### DIFF
--- a/blocks/community_product/view.php
+++ b/blocks/community_product/view.php
@@ -112,7 +112,7 @@ if (isset($product) && is_object($product) && $product->isActive()) {
                                     echo t('On Sale') . ': <span class="store-sale-price">' . $formattedSalePrice . '</span>';
                                     echo '&nbsp;' . t('was') . '&nbsp;';
                                     echo '<span class="store-original-price">' . $formattedOriginalPrice . '</span>';
-                                    echo '<meta itemprop="price" content="' . $formattedSalePrice . '" />';
+                                    echo '<meta itemprop="price" content="' . $salePrice . '" />';
                                     echo '<link itemprop="availability " href="' . $stockstatus . '"/>';
                                 } else {
 


### PR DESCRIPTION
I see this error in the Google Search Console:

```
Invalid price format in "price" property (in "offers") 
```

Checking the source code of the affectd page, I see this code:

```html
<meta itemprop="price" content="12,34 €" />
```

It should be
```html
<meta itemprop="price" content="12.34" />
```
