### PR TITLE
Add contexts to "Sale" translatable strings

### DIFF
--- a/blocks/community_suspension_message/controller.php
+++ b/blocks/community_suspension_message/controller.php
@@ -72,7 +72,7 @@ class Controller extends BlockController
      */
     public function getBlockTypeDescription()
     {
-        return t('Display a message to your customer when sales are suspended');
+        return tc(/* i18n: sale here means the act of selling */ 'Selling', 'Display a message to your customer when sales are suspended');
     }
 
     /**

--- a/blocks/community_suspension_message/view.php
+++ b/blocks/community_suspension_message/view.php
@@ -24,7 +24,7 @@ if (!$editMode) {
 $localization->pushActiveContext(Localization::CONTEXT_UI);
 ?>
 <div class="ccm-edit-mode-disabled-item">
-    <?= t('When the sales will be suspended, site visitors will see the following message:') ?>
+    <?= tc(/* i18n: sale here means the act of selling */ 'Selling', 'When the sales will be suspended, site visitors will see the following message:') ?>
     <div<?= $cssClass === '' ? '' : (' class="' . h($cssClass) . '"') ?>>
         <?= $message ?>
     </div>

--- a/controllers/single_page/dashboard/store/reports/sales.php
+++ b/controllers/single_page/dashboard/store/reports/sales.php
@@ -53,7 +53,7 @@ class Sales extends DashboardPageController
         $this->set('paginator', $paginator);
 
         $this->requireAsset('css', 'communityStoreDashboard');
-        $this->set('pageTitle', t('Sales Report'));
+        $this->set('pageTitle', tc(/* i18n: sale here means the act of selling */ 'Selling', 'Sales Report'));
     }
 
     public function export()

--- a/single_pages/dashboard/store/discounts.php
+++ b/single_pages/dashboard/store/discounts.php
@@ -348,8 +348,11 @@ if (version_compare($version, '9.0', '<')) {
         </div>
 
       <div class="form-group">
-          <?= $form->label('drDiscountSalePrices', t('Discount Sale Prices'))?>
-          <?= $form->select('drDiscountSalePrices', array('0'=>t('No, sale prices will not be discounted'), '1' => t('Yes, sale prices will have discounts applied')), $discountRule->getDiscountSalePrices())?>
+          <?= $form->label('drDiscountSalePrices', tc(/* i18n: sale here means the act of discounting */ 'Discounting', 'Discount Sale Prices'))?>
+          <?= $form->select('drDiscountSalePrices', [
+              '0' => tc(/* i18n: sale here means the act of discounting */ 'Discounting', 'No, sale prices will not be discounted'),
+              '1' => tc(/* i18n: sale here means the act of discounting */ 'Discounting', 'Yes, sale prices will have discounts applied'),
+          ], $discountRule->getDiscountSalePrices())?>
       </div>
 
         <div class="form-group">

--- a/single_pages/dashboard/store/overview.php
+++ b/single_pages/dashboard/store/overview.php
@@ -71,7 +71,7 @@ if (isset($missingNotificationEmails)) { ?>
             <div class="card-body">
                 <?php $ts = $sr->getTodaysSales(); ?>
                 <div class="panel-heading">
-                    <h4 class="panel-title card-title"><?= tc(/* i18n: sale here means the act of selling */ 'Selling', "Today's Sales") ?></h4>
+                    <h4 class="panel-title card-title"><?= tc(/* i18n: orders that have been placed */ 'Orders', "Today's Sales") ?></h4>
                 </div>
                 <div class="panel-body">
                     <div class="row">
@@ -100,7 +100,7 @@ if (isset($missingNotificationEmails)) { ?>
             <div class="card-body">
                 <?php $ts = $sr->getTodaysSales(); ?>
                 <div class="panel-heading">
-                    <h4 class="panel-title card-title"><?= tc(/* i18n: sale here means the act of selling */ 'Selling', 'Sales this Week') ?></h4>
+                    <h4 class="panel-title card-title"><?= tc(/* i18n: orders that have been placed */ 'Orders', 'Sales this Week') ?></h4>
                 </div>
                 <div class="panel-body">
 
@@ -108,7 +108,7 @@ if (isset($missingNotificationEmails)) { ?>
                     <div id="sales-chart"></div>
                 </div>
                 <div class="panel-footer">
-                    <a href="<?= Url::to('/dashboard/store/reports') ?>"><i class="fa fa-line-chart fa-chart-line"></i> <?= tc(/* i18n: sale here means the act of selling */ 'Selling', 'View Sales Report') ?></a>
+                    <a href="<?= Url::to('/dashboard/store/reports') ?>"><i class="fa fa-line-chart fa-chart-line"></i> <?= tc(/* i18n: orders that have been placed */ 'Orders', 'View Sales Report') ?></a>
                 </div>
             </div>
         </div>

--- a/single_pages/dashboard/store/overview.php
+++ b/single_pages/dashboard/store/overview.php
@@ -35,7 +35,9 @@ if ($shoppingDisabled) {
     <?php 
 } elseif ($salesSuspended) {
     ?>
-    <p class="alert alert-warning text-center"><?= t(
+    <p class="alert alert-warning text-center"><?= tc(
+        /* i18n: sale here means the act of selling */
+        'Selling', 
         'Sales are currently suspended. This setting can be changed via the %ssettings page%s.',
         '<a href="' . Url::to('/dashboard/store/settings#settings-sales-suspension') . '">',
         '</a>'
@@ -69,7 +71,7 @@ if (isset($missingNotificationEmails)) { ?>
             <div class="card-body">
                 <?php $ts = $sr->getTodaysSales(); ?>
                 <div class="panel-heading">
-                    <h4 class="panel-title card-title"><?= t("Today's Sales") ?></h4>
+                    <h4 class="panel-title card-title"><?= tc(/* i18n: sale here means the act of selling */ 'Selling', "Today's Sales") ?></h4>
                 </div>
                 <div class="panel-body">
                     <div class="row">
@@ -98,7 +100,7 @@ if (isset($missingNotificationEmails)) { ?>
             <div class="card-body">
                 <?php $ts = $sr->getTodaysSales(); ?>
                 <div class="panel-heading">
-                    <h4 class="panel-title card-title"><?= t("Sales this Week") ?></h4>
+                    <h4 class="panel-title card-title"><?= tc(/* i18n: sale here means the act of selling */ 'Selling', 'Sales this Week') ?></h4>
                 </div>
                 <div class="panel-body">
 
@@ -106,7 +108,7 @@ if (isset($missingNotificationEmails)) { ?>
                     <div id="sales-chart"></div>
                 </div>
                 <div class="panel-footer">
-                    <a href="<?= Url::to('/dashboard/store/reports') ?>"><i class="fa fa-line-chart fa-chart-line"></i> <?= t('View Sales Report') ?></a>
+                    <a href="<?= Url::to('/dashboard/store/reports') ?>"><i class="fa fa-line-chart fa-chart-line"></i> <?= tc(/* i18n: sale here means the act of selling */ 'Selling', 'View Sales Report') ?></a>
                 </div>
             </div>
         </div>

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -342,15 +342,17 @@ if (version_compare($version, '9.0', '<')) {
 
                         <div class="col-md-6">
                             <div class="form-group nonpriceentry <?= ($product->allowCustomerPrice() ? 'hidden d-none' : ''); ?>">
-                                <?= $form->label("pSalePrice", t('Sale Price'), ['class' => $priceclass]); ?>
+                                <?= $form->label("pSalePrice", tc(/* i18n: sale here means the act of discounting */ 'Discounting', 'Sale Price'), ['class' => $priceclass]); ?>
                                 <div class="input-group">
                                     <div class="input-group-addon input-group-text">
                                         <?= Config::get('community_store.symbol'); ?>
                                     </div>
                                     <?php $salePrice = $product->getSalePriceValue(); ?>
-                                    <?= $form->number("pSalePrice", $salePrice, ['step'=>'0.01', 'placeholder' => t('No Sale Price Set')]); ?>
+                                    <?= $form->number("pSalePrice", $salePrice, ['step'=>'0.01', 'placeholder' => tc(/* i18n: sale here means the act of discounting */ 'Discounting', 'No Sale Price Set')]); ?>
                                 </div>
-                                <span class="help-block <?=($salePrice ? 'hidden d-none' : ''); ?>" id="saleNote"><?= t('Enter a value to set start and end dates for the sale'); ?></span>
+                                <span class="help-block <?=($salePrice ? 'hidden d-none' : ''); ?>" id="saleNote">
+                                    <?= tc(/* i18n: sale here means the act of discounting */ 'Discounting', 'Enter a value to set start and end dates for the sale') ?>
+                                </span>
 
                                 <script>
                                     $(document).ready(function () {
@@ -387,7 +389,7 @@ if (version_compare($version, '9.0', '<')) {
                         <div class="col-md-12">
 
                             <div class="form-group nonpriceentry <?= ($product->allowCustomerPrice() ? 'hidden d-none' : ''); ?>">
-                                <?= $form->label("pSaleStart", t('Sale Start')); ?>
+                                <?= $form->label("pSaleStart", tc(/* i18n: sale here means the act of discounting */ 'Discounting', 'Sale Start')); ?>
                                 <?= $app->make('helper/form/date_time')->datetime('pSaleStart', $product->getSaleStart()); ?>
                             </div>
 
@@ -396,7 +398,7 @@ if (version_compare($version, '9.0', '<')) {
                         <div class="col-md-12">
 
                             <div class="form-group nonpriceentry <?= ($product->allowCustomerPrice() ? 'hidden d-none' : ''); ?>">
-                                <?= $form->label("pSaleEnd", t('Sale End')); ?>
+                                <?= $form->label("pSaleEnd", tc(/* i18n: sale here means the act of discounting */ 'Discounting', 'Sale End')); ?>
                                 <?= $app->make('helper/form/date_time')->datetime('pSaleEnd', $product->getSaleEnd()); ?>
                             </div>
                             <style>
@@ -447,7 +449,9 @@ if (version_compare($version, '9.0', '<')) {
                             <div class="form-group">
                                 <?= $form->checkbox('pQuantityPrice', '1', $product->hasQuantityPrice()) ?>
                                 <?= $form->label('pQuantityPrice', t('Quantity based pricing')) ?>
-                                <span id="tieredoptionsnote" class="help-block <?= $product->hasQuantityPrice() ? '' : 'hidden d-none' ?>"><?= t('Note: quantity based pricing is not overridden by a sale price'); ?></span>
+                                <span id="tieredoptionsnote" class="help-block <?= $product->hasQuantityPrice() ? '' : 'hidden d-none' ?>">
+                                    <?= tc(/* i18n: sale here means the act of discounting */ 'Discounting', 'Note: quantity based pricing is not overridden by a sale price') ?>
+                                </span>
                             </div>
                         </div>
 
@@ -1626,13 +1630,21 @@ if (version_compare($version, '9.0', '<')) {
                                                 <div class="row <?= ($hideVariationPrices ? 'hidden d-none' : ''); ?>">
                                                     <div class="col-md-6">
                                                         <div class="form-group">
-                                                            <?= $form->label("pvSalePrice[]", t('Sale Price')); ?>
+                                                            <?= $form->label("pvSalePrice[]", tc(/* i18n: sale here means the act of discounting */ 'Discounting', 'Sale Price')); ?>
 
                                                             <div class="input-group">
                                                                 <div class="input-group-addon input-group-text">
                                                                     <?= Config::get('community_store.symbol'); ?>
                                                                 </div>
-                                                                <?= $form->number("pvSalePrice[" . $varid . "]", $variation ? $variation->getVariationSalePrice() : '', ['step'=>'0.01', 'max'=>'9999999.99', 'placeholder' => t('Base Sale Price')]); ?>
+                                                                <?= $form->number(
+                                                                    "pvSalePrice[" . $varid . "]",
+                                                                    $variation ? $variation->getVariationSalePrice() : '',
+                                                                    [
+                                                                        'step' => '0.01',
+                                                                        'max' => '9999999.99',
+                                                                        'placeholder' => tc(/* i18n: sale here means the act of discounting */ 'Discounting', 'Base Sale Price'),
+                                                                    ]
+                                                                ) ?>
                                                             </div>
                                                         </div>
                                                     </div>

--- a/single_pages/dashboard/store/reports/products/sheet.php
+++ b/single_pages/dashboard/store/reports/products/sheet.php
@@ -17,7 +17,7 @@ $weightLabel = Config::get('community_store.weightUnit');
         <th><?= t('Active'); ?></th>
         <th><?= t('Configuration'); ?></th>
         <th class="text-right"><?= t('Price'); ?></th>
-        <th class="text-right"><?= t('Sale Price'); ?></th>
+        <th class="text-right"><?= tc(/* i18n: sale here means the act of discounting */ 'Discounting', 'Sale Price'); ?></th>
         <th><?= t('Shipping Data'); ?></th>
         <th  class="text-right"><?= t('Stock Level'); ?></th>
     </tr>

--- a/single_pages/dashboard/store/reports/sales.php
+++ b/single_pages/dashboard/store/reports/sales.php
@@ -23,7 +23,7 @@ if ($taxCalc == 'extract') {
 		<div class="panel-sale panel panel-default mb-3">
 			<?php $ts = SalesReport::getTodaysSales(); ?>
 			<div class="panel-heading">
-				<h2 class="panel-title"><?= t("Today's Sales")?></h2>
+				<h2 class="panel-title"><?= tc(/* i18n: sale here means the act of selling */ 'Selling', "Today's Sales")?></h2>
 			</div>
 			<div class="panel-body">
 				<div class="row">

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -54,7 +54,7 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
                 <li class="nav-item"><a class="nav-link text-primary" href="#settings-checkout" data-pane-toggle><?= t('Cart and Checkout'); ?></a></li>
                 <li class="nav-item"><a class="nav-link text-primary" href="#settings-orders" data-pane-toggle><?= t('Orders'); ?></a></li>
                 <li class="nav-item"><a class="nav-link text-primary" href="#settings-user-interface" data-pane-toggle><?= t('User Interface'); ?></a></li>
-                <li class="nav-item"><a class="nav-link text-primary" href="#settings-sales-suspension" data-pane-toggle><?= t('Sales Suspension'); ?></a></li>
+                <li class="nav-item"><a class="nav-link text-primary" href="#settings-sales-suspension" data-pane-toggle><?= tc(/* i18n: sale here means the act of selling */ 'Selling', 'Sales Suspension'); ?></a></li>
             </ul>
 
         </div>
@@ -742,7 +742,7 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
 
                 <div class="checkbox form-check">
                     <label><?= $form->checkbox('hideSalePrice', true, Config::get('community_store.hideSalePrice')); ?>
-                        <?= t('Hide sale price'); ?>
+                        <?= tc(/* i18n: sale here means the act of discounting */ 'Discounting', 'Hide sale price'); ?>
                     </label>
                 </div>
 
@@ -808,34 +808,34 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
 
         <!-- #settings-sales-suspension -->
         <div class="col-sm-9 store-pane" id="settings-sales-suspension">
-            <h3><?= t('Sales Suspension') ?></h3>
+            <h3><?= tc(/* i18n: sale here means the act of selling */ 'Selling', 'Sales Suspension') ?></h3>
 
             <div class="form-group">
-                <?= $form->label('salesSuspensionSuspend', t('Suspend Sales')); ?>
+                <?= $form->label('salesSuspensionSuspend', tc(/* i18n: sale here means the act of selling */ 'Selling', 'Suspend Sales')); ?>
                 <?= $form->select(
                     'salesSuspensionSuspend',
                     [
-                        '0' => t('Sales are active'),
-                        '1' => t('Sales are disabled (Catalog Mode)'),
-                        '2' => t('Sales are temporarily suspended')
+                        '0' => tc(/* i18n: sale here means the act of selling */ 'Selling', 'Sales are active'),
+                        '1' => tc(/* i18n: sale here means the act of selling */ 'Selling', 'Sales are disabled (Catalog Mode)'),
+                        '2' => tc(/* i18n: sale here means the act of selling */ 'Selling', 'Sales are temporarily suspended')
                     ],
                     $salesSuspension->salesPermanentlyDisabled() ? '1' : ($salesSuspension->isSuspended() ? '2' : '0')
                 ) ?>
             </div>
             <div class="form-group">
-                <?= $form->label('salesSuspensionMessage', t('Sales suspension message')); ?>
+                <?= $form->label('salesSuspensionMessage', tc(/* i18n: sale here means the act of selling */ 'Selling', 'Sales suspension message')); ?>
                 <?= $editor->outputStandardEditor('salesSuspensionMessage', $salesSuspension->getSuspensionMessage(true)) ?>
                 <div class="small text-muted"><?= t('Leave empty to use the default message') ?></div>
             </div>
             <div class="form-group salesSuspensionSuspend-on"<?= $salesSuspension->isSuspended() ? '' : ' style="display:none"' ?>>
                 <?= $form->label('salesSuspensionFrom', t('Date/time when the suspension starts')) ?>
                 <?= $dateTimeWidget->datetime('salesSuspensionFrom', $salesSuspension->getSuspendedFrom()) ?>
-                <div class="small text-muted"><?= t('Leave empty to suspend sales immediately') ?></div>
+                <div class="small text-muted"><?= tc(/* i18n: sale here means the act of selling */ 'Selling', 'Leave empty to suspend sales immediately') ?></div>
             </div>
             <div class="form-group salesSuspensionSuspend-on"<?= $salesSuspension->isSuspended() ? '' : ' style="display:none"' ?>>
                 <?= $form->label('salesSuspensionTo', t('Date/time when the suspension ends')) ?>
                 <?= $dateTimeWidget->datetime('salesSuspensionTo', $salesSuspension->getSuspendedTo()) ?>
-                <div class="small text-muted"><?= t('Leave empty to suspend sales indefinitely') ?></div>
+                <div class="small text-muted"><?= tc(/* i18n: sale here means the act of selling */ 'Selling', 'Leave empty to suspend sales indefinitely') ?></div>
             </div>
         </div>
         <script>

--- a/src/CommunityStore/Utilities/SalesSuspension.php
+++ b/src/CommunityStore/Utilities/SalesSuspension.php
@@ -142,7 +142,7 @@ class SalesSuspension
         if ($message === '') {
             $to = $this->getSuspendedTo();
 
-            return $to === null ? t('Sales are currently suspended.') : t('Sales are currently suspended until %s.', $this->dateService->formatDateTime($to, true));
+            return $to === null ? tc(/* i18n: sale here means the act of selling */ 'Selling', 'Sales are currently suspended.') : tc(/* i18n: sale here means the act of selling */ 'Selling', 'Sales are currently suspended until %s.', $this->dateService->formatDateTime($to, true));
         }
 
         return LinkAbstractor::translateFrom($message);


### PR DESCRIPTION
I added a context and a note for translators in all the translatable strings that contain "sale": that way it will be clear if "sale" refers to discounting or to selling.

Of course, a review by a native speaking developer is much appreciated (guess who am I talking about? :wink:)

Close #795