### PR TITLE
Upgrade package version number

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -20,7 +20,7 @@ class Controller extends Package
 {
     protected $pkgHandle = 'community_store';
     protected $appVersionRequired = '8.5';
-    protected $pkgVersion = '2.6.0';
+    protected $pkgVersion = '2.6.1-alpha1';
 
     protected $npmPackages = [
         'sysend' => '1.3.4',


### PR DESCRIPTION
When fetching the translations from translate.concretecms.org, Concrete passes it the package version (this is required in order to fetch the translations for the currently installed package version).

At the moment, the package version is 2.6.0, and because there's a git tag associated to it, in translate.concretecms.org there's the [an exact version](https://translate.concretecms.org/translate/package/community_store/2.6) corresponding to it.

So, translate.concretecms.org provides the translations for version 2.6.0.

But what happens if we have the latest `master` installed? The translatable strings in the package are newer, but translate.concretecms.org still provides the older ones.

The solution? Define a package version in `master` that's greater than the latest tag. That way, translate.concretecms.org will provide the strings for the "[2 development series](https://translate.concretecms.org/translate/package/community_store/dev-2)" (which comes from `master`).