### PR TITLE
Allow filtering products by featured/not featured

### DIFF
--- a/controllers/element/products/search.php
+++ b/controllers/element/products/search.php
@@ -55,9 +55,17 @@ class Search extends ElementController
         $this->set('gID', $this->gID);
         $this->set('groupList', $this->groupList);
         $this->set('token', $this->app->make('token'));
-
-        $this->set('keywords', $this->app->request->request('keywords'));
-
+        $request = isset($this->request) ? $this->request : $this->app->request;
+        $this->set('keywords', $request->request('keywords'));
+        $featured = $request->request('featured');
+        if ($featured) {
+            $featured = true;
+        } elseif ($featured !== null && $featured !== '') {
+            $featured = false;
+        } else {
+            $featured = null;
+        }
+        $this->set('featured', $featured);
         if (isset($this->headerSearchAction)) {
             $this->set('headerSearchAction', $this->headerSearchAction);
         } else {

--- a/controllers/single_page/dashboard/store/products.php
+++ b/controllers/single_page/dashboard/store/products.php
@@ -65,12 +65,22 @@ class Products extends DashboardSitePageController
         }
 
         $keywords = trim($this->request->query->get('keywords'));
-
         if ($keywords) {
             $productsList->setSearch($keywords);
             Session::set('communitystore.dashboard.products.keywords', $keywords);
         } else {
             Session::remove('communitystore.dashboard.products.keywords');
+        }
+
+        $featured = $this->request->query->get('featured');
+        if ($featured) {
+            $productsList->setFeaturedOnly(true);
+            Session::set('communitystore.dashboard.products.featured', true);
+        } elseif ($featured !== null && $featured !== '') {
+            $productsList->setNotFeaturedOnly(true);
+            Session::set('communitystore.dashboard.products.featured', false);
+        } else {
+            Session::remove('communitystore.dashboard.products.featured');
         }
 
         $this->set('productList', $productsList);
@@ -335,6 +345,7 @@ class Products extends DashboardSitePageController
         $this->set('usergroups', $usergrouparray);
 
         $this->set('keywordsSearch', Session::get('communitystore.dashboard.products.keywords'));
+        $this->set('featuredSearch', Session::get('communitystore.dashboard.products.featured'));
         $this->set('groupSearch', Session::get('communitystore.dashboard.products.group'));
 
         if (method_exists($this, 'createBreadcrumb')) {

--- a/elements/products/search.php
+++ b/elements/products/search.php
@@ -2,16 +2,20 @@
 
 defined('C5_EXECUTE') or die("Access Denied.");
 
-use Concrete\Core\Form\Service\Form;
 use Concrete\Core\Support\Facade\Url;
 
-/** @var string $headerSearchAction */
-/** @var Form $form */
+/**
+ * @var string $headerSearchAction
+ * @var Concrete\Core\Form\Service\Form $form
+ * @var string|null $keywords
+ * @var bool|null $featured
+ * @var Concrete\Core\User\Group\Group[]|null $groupList
+ * @var int|string|null $gID
+ */
 ?>
 
 <div class="ccm-header-search-form ccm-ui" data-header="file-manager">
     <form method="get" class="row row-cols-auto g-0 align-items-center" action="<?php echo $headerSearchAction ?>">
-
         <div class="ccm-header-search-form-input input-group">
             <?php if ($groupList) {
                 $currentFilter = '';
@@ -41,12 +45,55 @@ use Concrete\Core\Support\Facade\Url;
                 </div>
             <?php } ?>
 
-            <input type="search" id="keywords" name="keywords" value="<?= h($keywords); ?>" style="min-width: 220px" placeholder="<?= t('Search by Name or SKU') ?>" class="form-control border-end-0" autocomplete="off">
-            <button type="submit" class="input-group-icon">
-                <svg width="16" height="16">
-                    <use xlink:href="#icon-search"></use>
-                </svg>
-            </button>
+            <div class="input-group">
+                <input type="search" id="keywords" name="keywords" value="<?= h($keywords); ?>" style="min-width: 220px" placeholder="<?= t('Search by Name or SKU') ?>" class="form-control border-end-0" autocomplete="off">
+                <button type="submit" class="input-group-icon">
+                    <svg width="16" height="16">
+                        <use xlink:href="#icon-search"></use>
+                    </svg>
+                </button>
+                <div class="btn-group dropdown">
+                    <button class="px-3 btn btn-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                        <svg width="16" height="16">
+                            <use xlink:href="#icon-cog"></use>
+                        </svg>
+                        <span class="caret"></span>
+                    </button>
+                    <ul class="dropdown-menu" role="menu">
+                        <li class="dropdown-item<?= $featured === null ? ' active' : '' ?>">
+                            <a class="nav-link" href="#" data-cs-filter-featured=""><?= tc('Products', 'Featured and not featured') ?></a>
+                        </li>
+                        <li class="dropdown-item<?= $featured === true ? ' active' : '' ?>">
+                            <a class="nav-link" href="#" data-cs-filter-featured="1"><?= tc('Products', 'Only featured') ?></a>
+                        </li>
+                        <li class="dropdown-item<?= $featured === false ? ' active' : '' ?>">
+                            <a class="nav-link" href="#" data-cs-filter-featured="0"><?= tc('Products', 'Only not featured') ?></a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
         </div>
+        <input type="hidden" name="featured" value="<?= $featured === null ? '' : ($featured ? '1' : '0') ?>" />
     </form>
 </div>
+<script>
+$(document).ready(function() {
+
+$('a[data-cs-filter-featured]').on('click', function(e) {
+    e.preventDefault();
+    var $a = $(this),
+        featured = $a.data('cs-filter-featured'),
+        $form = $a.closest('form'),
+        $featured = $form.find('input[name="featured"]');
+    if (typeof featured === 'number') {
+        featured = featured.toString();
+    }
+    if ($featured.val() === featured) {
+        return;
+    }
+    $featured.val(featured);
+    $form.submit();
+});
+
+});
+</script>

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -2029,7 +2029,16 @@ if (version_compare($version, '9.0', '<')) {
 
         <div class="ccm-dashboard-form-actions-wrapper">
             <div class="ccm-dashboard-form-actions">
-                <a href="<?= Url::to('/dashboard/store/products/'. (isset($groupSearch) ? $groupSearch : '') . (isset($keywordsSearch) ? '?keywords='.urlencode($keywordsSearch) : '')) ?>" class="btn btn-default btn-secondary pull-left float-start"><?= t("Cancel / View All Products") ?></a>
+                <?php
+                $qs = [];
+                if (isset($keywordsSearch)) {
+                    $qs[] = 'keywords=' . urlencode($keywordsSearch);
+                }
+                if (isset($featuredSearch)) {
+                    $qs[] = 'featured=' . ($featuredSearch ? '1' : '0');
+                }
+                ?>
+                <a href="<?= Url::to('/dashboard/store/products/'. (isset($groupSearch) ? $groupSearch : '') . ($qs === [] ? '' : ('?' . implode('&', $qs)))) ?>" class="btn btn-default btn-secondary pull-left float-start"><?= t("Cancel / View All Products") ?></a>
                 <button class="float-end pull-right btn btn-primary" disabled="disabled" type="submit"><?= $actionDescription ?></button>
             </div>
         </div>

--- a/src/CommunityStore/Product/ProductList.php
+++ b/src/CommunityStore/Product/ProductList.php
@@ -21,6 +21,7 @@ class ProductList extends AttributedItemList implements PaginationProviderInterf
     protected $randomSeed = '';
     protected $sortByDirection = 'desc';
     protected $featuredOnly = false;
+    protected $notFeaturedOnly = false;
     protected $showOutOfStock = false;
     protected $saleOnly = false;
     protected $activeOnly = true;
@@ -83,6 +84,11 @@ class ProductList extends AttributedItemList implements PaginationProviderInterf
     public function setFeaturedOnly($bool)
     {
         $this->featuredOnly = $bool;
+    }
+
+    public function setNotFeaturedOnly($bool)
+    {
+        $this->notFeaturedOnly = $bool;
     }
 
     public function setManufacturer($manufacturer)
@@ -384,6 +390,9 @@ class ProductList extends AttributedItemList implements PaginationProviderInterf
         }
         if ($this->featuredOnly) {
             $query->andWhere("pFeatured = 1");
+        }
+        if ($this->notFeaturedOnly) {
+            $query->andWhere('pFeatured = 0');
         }
         if ($this->manufacturer) {
             $query->andWhere("pManufacturer = ?")->setParameter($paramcount++, $this->manufacturer);


### PR DESCRIPTION
What about adding an option to view only featured or not featured products in the `/dashboard/store/products` dashboard page?

Before:

![immagine](https://github.com/concretecms-community-store/community_store/assets/928116/d78b5ef1-7881-4090-9916-c3c9eb013e81)

After:

- ![immagine](https://github.com/concretecms-community-store/community_store/assets/928116/54b73d51-d484-469d-8035-983c58849297)
- ![immagine](https://github.com/concretecms-community-store/community_store/assets/928116/37706d07-0725-4a1f-ac31-81ca1ba1429d)
- ![immagine](https://github.com/concretecms-community-store/community_store/assets/928116/f9229be1-265a-48eb-bd47-e42e940a1630)
- ![immagine](https://github.com/concretecms-community-store/community_store/assets/928116/62d9b233-ea40-4866-9e6b-9fa747bf7c5d)
