### PR TITLE
Add a configurable option to automatically update quantities of products with variations

### DIFF
--- a/config/products.php
+++ b/config/products.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    // Set to true to handle automatically pQty/pQtyUnlim for products with variations
+    'autoQuantityIfVariations' => false,
+];

--- a/controller.php
+++ b/controller.php
@@ -247,7 +247,7 @@ class Controller extends Package
             try {
                 $app = $this->app->make('console');
                 $app->add(new Src\CommunityStore\Console\Command\ResetCommand());
-            } catch (Exception $e) {
+            } catch (\Exception $e) {
             }
         }
     }

--- a/controller.php
+++ b/controller.php
@@ -1,26 +1,29 @@
 <?php
 namespace Concrete\Package\CommunityStore;
 
-use Concrete\Core\Package\Package;
-use Concrete\Core\Page\Template as PageTemplate;
-use Concrete\Package\CommunityStore\Src\CommunityStore\Payment\Method as PaymentMethod;
-use Concrete\Package\CommunityStore\Src\CommunityStore\Shipping\Method\ShippingMethodType as ShippingMethodType;
-use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Installer;
-use Concrete\Core\Support\Facade\Route;
 use Concrete\Core\Asset\Asset;
 use Concrete\Core\Asset\AssetList;
-use Concrete\Core\Support\Facade\Url;
+use Concrete\Core\Command\Task\Manager as TaskManager;
 use Concrete\Core\Multilingual\Page\Section\Section;
-use Concrete\Core\Support\Facade\Config;
-use Concrete\Core\Page\Type\Type as PageType;
+use Concrete\Core\Package\Package;
 use Concrete\Core\Page\Page;
+use Concrete\Core\Page\Template as PageTemplate;
+use Concrete\Core\Page\Type\Type as PageType;
+use Concrete\Core\Support\Facade\Config;
+use Concrete\Core\Support\Facade\Route;
+use Concrete\Core\Support\Facade\Url;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Payment\Method as PaymentMethod;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Shipping\Method\ShippingMethodType as ShippingMethodType;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\DoctrineORMEventsSubscriber;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Installer;
+use Doctrine\ORM\EntityManagerInterface;
 use Whoops\Exception\ErrorException;
 
 class Controller extends Package
 {
     protected $pkgHandle = 'community_store';
     protected $appVersionRequired = '8.5';
-    protected $pkgVersion = '2.6.1-alpha1';
+    protected $pkgVersion = '2.6.1-alpha2';
 
     protected $npmPackages = [
         'sysend' => '1.3.4',
@@ -64,6 +67,8 @@ class Controller extends Package
         Installer::createDDFileset($pkg);
         Installer::installOrderStatuses($pkg);
         Installer::installDefaultTaxClass($pkg);
+        Installer::installJobs();
+        Installer::installTasks();
     }
 
     public function install()
@@ -118,7 +123,7 @@ class Controller extends Package
             parent::upgrade();
         }
 
-        Installer::upgrade($pkg);
+        Installer::upgrade($pkg, self::$upgradingFromVersion);
         $this->app->clearCaches();
     }
 
@@ -175,6 +180,7 @@ class Controller extends Package
         $this->registerHelpers();
         $this->registerRoutes();
         $this->registerCategories();
+        $this->registerEventSubscribers();
 
         $version = $this->getPackageVersion();
 
@@ -247,8 +253,16 @@ class Controller extends Package
             try {
                 $app = $this->app->make('console');
                 $app->add(new Src\CommunityStore\Console\Command\ResetCommand());
+                $app->add(new Src\CommunityStore\Console\Command\AutoUpdateQuantitiesFromVariations());
             } catch (\Exception $e) {
             }
+        }
+
+        if (class_exists(TaskManager::class)) {
+            $manager = $this->app->make(TaskManager::class);
+            $manager->extend('auto_update_quantities_from_variations', function () {
+                return $this->app->make(\Concrete\Package\CommunityStore\Src\CommunityStore\Command\Task\Controller\AutoUpdateQuantitiesFromVariations::class);
+            });
         }
     }
 
@@ -324,5 +338,12 @@ class Controller extends Package
                 return $app->make('Concrete\Package\CommunityStore\Attribute\Category\OrderCategory');
             }
         );
+    }
+
+    private function registerEventSubscribers()
+    {
+        $subscriber = $this->app->make(DoctrineORMEventsSubscriber::class);
+        $entityManager = $this->app->make(EntityManagerInterface::class);
+        $entityManager->getEventManager()->addEventSubscriber($subscriber);
     }
 }

--- a/controllers/single_page/dashboard/store/products.php
+++ b/controllers/single_page/dashboard/store/products.php
@@ -456,14 +456,13 @@ class Products extends DashboardSitePageController
     {
         $data = $this->request->request->all();
 
-        $payload = json_decode($this->request->get('variationJSON'), true);
-        if ($payload) {
-            $variations = [];
-            parse_str($payload, $variations);
-            $data = array_merge($data, $variations);
-        }
-
-        if ($this->request->request->all() && $this->token->validate('community_store')) {
+        if ($data && $this->token->validate('community_store')) {
+            $payload = json_decode($this->request->get('variationJSON'), true);
+            if ($payload) {
+                $variations = [];
+                parse_str($payload, $variations);
+                $data = array_merge($data, $variations);
+            }
             $errors = $this->validate($data);
             $this->error = null; //clear errors
             $this->error = $errors;

--- a/controllers/single_page/dashboard/store/settings.php
+++ b/controllers/single_page/dashboard/store/settings.php
@@ -165,7 +165,6 @@ class Settings extends DashboardPageController
             if (!$errors->has()) {
                 $salesSuspension = $this->app->make(SalesSuspension::class);
                 $dateTimeWidget = $this->app->make(Widget\DateTime::class);
-                $startingCurrency =  Config::get('community_store.currency');
 
                 Config::save('community_store.symbol', $args['symbol']);
                 Config::save('community_store.currency', $args['currency']);

--- a/jobs/auto_update_quantities_from_variations.php
+++ b/jobs/auto_update_quantities_from_variations.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Concrete\Package\CommunityStore\Job;
+
+use Concrete\Core\Job\Job;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\AutoUpdaterQuantitiesFromVariations;
+
+class AutoUpdateQuantitiesFromVariations extends Job
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see Job::getJobName()
+     */
+    public function getJobName()
+    {
+        return t('Automatic Product Quantity Updater');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see Job::getJobDescription()
+     */
+    public function getJobDescription()
+    {
+        return t('Update the product quantities from variations.');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see Job::run()
+     */
+    public function run()
+    {
+        $app = Application::getFacadeApplication();
+        $updater = $app->make(AutoUpdaterQuantitiesFromVariations::class);
+        if (!$updater->isEnabled()) {
+            return t('Quantities for products with variations is configured to be performed manually.');
+        }
+        $num = $updater->updateAll();
+
+        return t2('%s product has been updated', '%s products have been updated', $num);
+    }
+}

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -1,11 +1,12 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
 
-use \Concrete\Core\Page\Page;
-use \Concrete\Core\Support\Facade\Url;
-use \Concrete\Core\Support\Facade\Config;
-use \Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Support\Facade\Config;
+use Concrete\Core\Support\Facade\Url;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductVariation\ProductVariation;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\AutoUpdaterQuantitiesFromVariations;
 
 /**
  * @var ProductVariation $variationLookup []
@@ -31,6 +32,7 @@ if (version_compare($version, '9.0', '<')) {
 ?>
 
 <?php if (in_array($controller->getAction(), $addViews)) { //if adding or editing a product
+    $automaticProductQuantities = $app->make(AutoUpdaterQuantitiesFromVariations::class)->isEnabled();
     if (!isset($product) || !is_object($product)) {
         $product = new Product();
         $product->setIsUnlimited(true);
@@ -159,7 +161,7 @@ if (version_compare($version, '9.0', '<')) {
                                 <?= $form->select("pActive", ['1' => t('Active'), '0' => t('Inactive')], $product->isActive() ? '1' : '0'); ?>
                             </div>
                         </div>
-                        <div class="col-lg-5">
+                        <div id="main-product-stock-level" class="col-lg-5<?= $automaticProductQuantities && $product->hasVariations() ? ' hidden d-none' : ''?>">
                         <div class="form-group">
                             <?= $form->label("pQty", t('Stock Level')); ?>
                             <?php $qty = $product->getStockLevel(); ?>
@@ -219,10 +221,24 @@ if (version_compare($version, '9.0', '<')) {
                                         $('#pVariations').change(function () {
                                             if ($(this).prop('checked')) {
                                                 $('#variations,#variationnotice').removeClass('hidden d-none');
+                                                <?php
+                                                if ($automaticProductQuantities) {
+                                                    ?>
+                                                    $('#main-product-stock-level').addClass('hidden d-none');;
+                                                    <?php
+                                                }
+                                                ?>
                                             } else {
                                                 $('#variations,#variationnotice').addClass('hidden d-none');
+                                                <?php
+                                                if ($automaticProductQuantities) {
+                                                    ?>
+                                                    $('#main-product-stock-level').removeClass('hidden d-none');
+                                                    <?php
+                                                }
+                                                ?>
                                             }
-                                        });
+                                        }).trigger('change');
 
                                         $('#pType').change(function () {
 

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -4,6 +4,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 use Concrete\Core\Support\Facade\Config;
 use Concrete\Core\Support\Facade\Url;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\AutoUpdaterQuantitiesFromVariations;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
 
 /**
@@ -25,6 +26,7 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
  * @var int|null $digitalDownloadFileSet
  * @var int|false|null $productPublishTarget
  * @var Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\SalesSuspension $salesSuspension
+ * @var string $automaticProductQuantitiesMessage
  */
 
 ?>
@@ -442,6 +444,18 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
                     <div class="radio"><label><?= $form->radio('attributesRequireType', '1', Config::get('community_store.attributesRequireType')  ? '1' : ''); ?><?php echo t('No, product attributes are only editable when a product type is selected'); ?></label></div>
                 </div>
 
+            </div>
+
+            <div class="form-group">
+                <label><?= t('Calculate automatically the quantities for products with variations') ?></label>
+                <div class="checkbox form-check">
+                    <?php
+                    $automaticProductQuantities = Config::get(AutoUpdaterQuantitiesFromVariations::CONFIGURATION_KEY) ? '1' : '0';
+                    ?>
+                    <div class="radio"><label><?= $form->radio('automaticProductQuantities', '1', $automaticProductQuantities) ?><?= t('Yes, product quantities will be derived from variations') ?></label></div>
+                    <div class="radio"><label><?= $form->radio('automaticProductQuantities', '0', $automaticProductQuantities) ?><?= t('No, I will manually manage product quantities') ?></label></div>
+                </div>
+                <div class="small text-muted"><?= $automaticProductQuantitiesMessage ?></div>
             </div>
 
         </div>

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -41,7 +41,7 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
         <div class="col-sm-3">
 
             <ul class="nav nav-pills nav-stacked flex-column">
-                <li class="nav-item active"><a class="nav-link text-primary"" href="#settings-currency" data-pane-toggle><?= t('Currency'); ?></a></li>
+                <li class="nav-item active"><a class="nav-link text-primary" href="#settings-currency" data-pane-toggle><?= t('Currency'); ?></a></li>
                 <li class="nav-item"><a class="nav-link text-primary" href="#settings-tax" data-pane-toggle><?= t('Tax'); ?></a></li>
                 <li class="nav-item"><a class="nav-link text-primary" href="#settings-shipping" data-pane-toggle><?= t('Shipping'); ?></a></li>
                 <li class="nav-item"><a class="nav-link text-primary" href="#settings-payments" data-pane-toggle><?= t('Payments'); ?></a></li>

--- a/src/CommunityStore/Command/AutoUpdateQuantitiesFromVariationsCommand.php
+++ b/src/CommunityStore/Command/AutoUpdateQuantitiesFromVariationsCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Concrete\Package\CommunityStore\Src\CommunityStore\Command;
+
+use Concrete\Core\Foundation\Command\Command;
+
+class AutoUpdateQuantitiesFromVariationsCommand extends Command
+{
+    private $force = false;
+
+    /**
+     * @return bool
+     */
+    public function isForce()
+    {
+        return $this->force;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setForce(bool $value): self
+    {
+        $this->force = $value;
+
+        return $this;
+    }
+}

--- a/src/CommunityStore/Command/AutoUpdateQuantitiesFromVariationsCommandHandler.php
+++ b/src/CommunityStore/Command/AutoUpdateQuantitiesFromVariationsCommandHandler.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Concrete\Package\CommunityStore\Src\CommunityStore\Command;
+
+use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\AutoUpdaterQuantitiesFromVariations;
+use Concrete\Core\Error\UserMessageException;
+
+class AutoUpdateQuantitiesFromVariationsCommandHandler
+{
+    /**
+     * @var \Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\AutoUpdaterQuantitiesFromVariations
+     */
+    private $service;
+
+    public function __construct(AutoUpdaterQuantitiesFromVariations $service)
+    {
+        $this->service = $service;
+    }
+
+    public function __invoke(AutoUpdateQuantitiesFromVariationsCommand $command)
+    {
+        if (!$command->isForce() && !$this->service->isEnabled()) {
+            throw new UserMessageException(t('Quantities for products with variations is configured to be performed manually.'));
+        }
+        $this->service->updateAll();
+    }
+}

--- a/src/CommunityStore/Command/Task/Controller/AutoUpdateQuantitiesFromVariations.php
+++ b/src/CommunityStore/Command/Task/Controller/AutoUpdateQuantitiesFromVariations.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Concrete\Package\CommunityStore\Src\CommunityStore\Command\Task\Controller;
+
+use Concrete\Core\Command\Task\TaskInterface;
+use Concrete\Core\Command\Task\Controller\AbstractController;
+use Concrete\Core\Command\Task\Input\InputInterface;
+use Concrete\Core\Command\Task\Runner\TaskRunnerInterface;
+use Concrete\Core\Command\Task\Runner\CommandTaskRunner;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Command\AutoUpdateQuantitiesFromVariationsCommand;
+use Concrete\Core\Command\Task\Input\Definition\Definition;
+use Concrete\Core\Command\Task\Input\Definition\BooleanField;
+
+class AutoUpdateQuantitiesFromVariations extends AbstractController
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Command\Task\Controller\ControllerInterface::getName()
+     */
+    public function getName(): string
+    {
+        return t('Automatic Product Quantity Updater');
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Command\Task\Controller\ControllerInterface::getDescription()
+     */
+    public function getDescription(): string
+    {
+        return t('Update the product quantities from variations.');
+    }
+    
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Command\Task\Controller\AbstractController::getInputDefinition()
+     */
+    public function getInputDefinition(): ?Definition
+    {
+        $definition = new Definition();
+        $definition->addField(new BooleanField('force', t('Force'), t('Force the execution even if automatic product quantities is disabled.')));
+
+        return $definition;
+    }
+
+    public function getTaskRunner(TaskInterface $task, InputInterface $input): TaskRunnerInterface
+    {
+        $command = new AutoUpdateQuantitiesFromVariationsCommand();
+        $force = $input->getField('force');
+        $command->setForce($force && !empty($force->getValue()));
+        
+        return new CommandTaskRunner($task, $command, t('Product quantities updated succesfully.'));
+    }
+}

--- a/src/CommunityStore/Console/Command/AutoUpdateQuantitiesFromVariations.php
+++ b/src/CommunityStore/Console/Command/AutoUpdateQuantitiesFromVariations.php
@@ -1,0 +1,80 @@
+<?php
+namespace Concrete\Package\CommunityStore\Src\CommunityStore\Console\Command;
+
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\AutoUpdaterQuantitiesFromVariations;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Concrete\Core\Error\UserMessageException;
+
+
+class AutoUpdateQuantitiesFromVariations extends Command
+{
+    protected function configure()
+    {
+        $this
+            ->setName('cstore:product:quantity:update')
+            ->setDescription('Update the quantities for products with variations')
+            ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force the execution even if automatic product quantities is disabled')
+            ->addOption('all', 'a', InputOption::VALUE_NONE, 'Update all the products with variations')
+            ->addOption('product', 'p', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Limit the execution only for the specific product ID(s)')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $app = Application::getFacadeApplication();
+        $service = $app->make(AutoUpdaterQuantitiesFromVariations::class);
+        if (!$service->isEnabled() && !$input->getOption('force')) {
+            $output->writeln('<error>Automatic quantities for products with variations is disabled (use the --force option to proceed anyway).</error>');
+
+            return 1;
+        }
+        $productIDs = $input->getOption('product');
+        if ($input->getOption('all') === ($productIDs !== [])) {
+            $output->writeln('<error>Please specify the products to be updated (--product option), or --all to update all products.</error>');
+
+            return 1;
+        }
+        if ($input->getOption('all')) {
+            $count = $service->updateAll();
+            $output->writeln("Number of updated products: <info>{$count}</info>");
+
+            return 0;
+        }
+        $em = $app->make(EntityManagerInterface::class);
+        $rc = 0;
+        $saveChanges = false;
+        foreach ($productIDs as $productID) {
+            $output->write("Updating product with ID {$productID}: ");
+            $product = $em->find(Product::class, $productID);
+            if ($product === null) {
+                $output->writeln('<error>not found.</error>');
+                $rc = 1;
+            } else {
+                try {
+                    if ($service->update($product)) {
+                        $output->writeln('<info>updated.</info>');
+                        $saveChanges = true;
+                    } else {
+                        $output->writeln('<info>already up-to-date.</info>');
+                    }
+                } catch (UserMessageException $x) {
+                    $output->writeln("<error>{$x->getMessage()}</error>");
+                    $rc = 1;
+                }
+            }
+        }
+        if ($saveChanges) {
+            $output->write('Saving changes... ');
+            $em->flush();
+            $output->writeln('<info>done.</info>');
+        }
+
+        return $rc;
+    }
+}

--- a/src/CommunityStore/Product/ProductVariation/ProductVariation.php
+++ b/src/CommunityStore/Product/ProductVariation/ProductVariation.php
@@ -196,6 +196,9 @@ class ProductVariation
         return $this->pID;
     }
 
+    /**
+     * @return \Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product
+     */
     public function getProduct() {
         return $this->product;
     }

--- a/src/CommunityStore/Product/ProductVariation/ProductVariation.php
+++ b/src/CommunityStore/Product/ProductVariation/ProductVariation.php
@@ -552,6 +552,7 @@ class ProductVariation
                         'pvDisabled' => 0,
                          true, ]
                     );
+                    $product->getVariations()->add($variation);
 
                     foreach ($optioncombo as $optionvalue) {
                         $option = ProductOptionItem::getByID($optionvalue);
@@ -707,6 +708,8 @@ class ProductVariation
 
     public function delete()
     {
+        $product = $this->getProduct();
+        $product->getVariations()->removeElement($this);
         $em = dbORM::entityManager();
         $em->remove($this);
         $em->flush();

--- a/src/CommunityStore/Utilities/AutoUpdaterQuantitiesFromVariations.php
+++ b/src/CommunityStore/Utilities/AutoUpdaterQuantitiesFromVariations.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Concrete\Package\CommunityStore\Src\CommunityStore\Utilities;
+
+use Concrete\Core\Config\Repository\Repository;
+use Doctrine\ORM\EntityManagerInterface;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product;
+use Concrete\Core\Error\UserMessageException;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductVariation\ProductVariation;
+
+/**
+ * Utilities for handling quantities of products with variations.
+ */
+final class AutoUpdaterQuantitiesFromVariations
+{
+    /**
+     * @var string
+     */
+    const CONFIGURATION_KEY = 'community_store::products.autoQuantityIfVariations';
+
+    /**
+     * @var \Concrete\Core\Config\Repository\Repository
+     */
+    private $config;
+
+    /**
+     * @var \Doctrine\ORM\EntityManagerInterface
+     */
+    private $em;
+
+    public function __construct(Repository $config, EntityManagerInterface $em)
+    {
+        $this->config = $config;
+        $this->em = $em;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled()
+    {
+        return (bool) $this->config->get(self::CONFIGURATION_KEY);
+    }
+
+    /**
+     * @param bool $value
+     *
+     * @return $this
+     */
+    public function setEnabled($value)
+    {
+        $value = (bool) $value;
+        $this->config->set(self::CONFIGURATION_KEY, $value);
+        $this->config->save(self::CONFIGURATION_KEY, $value);
+
+        return $this;
+    }
+
+    /**
+     * Update all the pQty/pQtyUnlim fields of products with variations.
+     * Please remark that this is performed at the database level, so you shouldn't use Doctrine Entities after executing this method.
+     *
+     * @return int the number of products that have been updated
+     */
+    public function updateAll()
+    {
+        /*
+         * It seems that Doctrine ORM doesn't support UPDATE queries with JOINs, so we have to use SQL directly.
+         */
+
+        return (int) $this->em->getConnection()->executeUpdate(<<<'EOT'
+UPDATE
+    CommunityStoreProducts AS p
+LEFT JOIN (
+    SELECT
+        pv.pID,
+        SUM(pv.pvQty) AS newQty,
+        MAX(COALESCE(pv.pvQtyUnlim, 0)) AS newQtyUnlim
+    FROM
+        CommunityStoreProductVariations AS pv
+    WHERE
+        pv.pvDisabled IS NULL OR pv.pvDisabled = 0
+    GROUP BY
+        pv.pID
+) AS t ON p.pID = t.pID
+SET
+    p.pQty = COALESCE(t.newQty, 0),
+    p.pQtyUnlim = COALESCE(t.newQtyUnlim, 0)
+WHERE
+    p.pVariations = 1
+EOT
+        );
+    }
+
+    /**
+     * Update the pQty/pQtyUnlim field of a product with variations.
+     *
+     * @throws \Concrete\Core\Error\UserMessageException if the product doesn't have variations.
+     *
+     * @return bool returns true if the product needed to be updated, false otherwise
+     */
+    public function update(Product $product)
+    {
+        if (!$product->hasVariations()) {
+            throw new UserMessageException(t("The product doesn't have variations."));
+        }
+        $pQty = 0;
+        $pQtyUnlim = false;
+        foreach ($product->getVariations() as $productVariation) {
+            if ($this->shouldConsiderVariation($productVariation)) {
+                $pQty += (float) $productVariation->getStockLevel();
+                $pQtyUnlim = $pQtyUnlim || $productVariation->getVariationQtyUnlim();
+            }
+        }
+        $result = false;
+        if ($pQty !== (float) $product->getStockLevel()) {
+            $product->setQty($pQty);
+            $result = true;
+        }
+        if ($pQtyUnlim !== (bool) $product->isUnlimited(true)) {
+            $product->setIsUnlimited($pQtyUnlim);
+            $result = true;
+        }
+
+        return $result;
+    }
+
+    private function shouldConsiderVariation(ProductVariation $productVariation)
+    {
+        if ($productVariation->getVariationDisabled()) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/CommunityStore/Utilities/DoctrineORMEventsSubscriber.php
+++ b/src/CommunityStore/Utilities/DoctrineORMEventsSubscriber.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Concrete\Package\CommunityStore\Src\CommunityStore\Utilities;
+
+use Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductVariation\ProductVariation;
+use Doctrine\Common\EventSubscriber;
+use Doctrine\ORM\Event\PreFlushEventArgs;
+use Doctrine\ORM\Events;
+
+class DoctrineORMEventsSubscriber implements EventSubscriber
+{
+    /**
+     * 
+     * @var \Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\AutoUpdaterQuantitiesFromVariations
+     */
+    private $service;
+
+    public function __construct(AutoUpdaterQuantitiesFromVariations $service)
+    {
+        $this->service = $service;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Doctrine\Common\EventSubscriber::getSubscribedEvents()
+     */
+    public function getSubscribedEvents()
+    {
+        return [
+            Events::preFlush,
+        ];
+    }
+
+    public function preFlush(PreFlushEventArgs $e)
+    {
+        if ($this->service->isEnabled()) {
+            $em = $e->getEntityManager();
+            $uow = $em->getUnitOfWork();
+            $map = $uow->getIdentityMap();
+            // Let's retrieve all the Product instances that have already been loaded (and possibily changed)
+            $products = isset($map[Product::class]) ? $map[Product::class] : [];
+            // Let's retrieve all the ProductVariation instances that have already been loaded (and possibily changed)
+            if (isset($map[ProductVariation::class])) {
+                foreach ($map[ProductVariation::class] as $productVariation) {
+                    $product = $productVariation->getProduct();
+                    if (!in_array($product, $products, true)) {
+                        $products[] = $product;
+                    }
+                }
+            }
+            foreach ($products as $product) {
+                if ($product->hasVariations()) {
+                    $this->service->update($product);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the following options at `/dashboard/store/settings#settings-products`:

![immagine](https://github.com/concretecms-community-store/community_store/assets/928116/eb65deca-aa16-476d-9d75-0fde7c8fd728)

If that option is enabled and a product has variations, users won't see this details when editing it:

![immagine](https://github.com/concretecms-community-store/community_store/assets/928116/5839728e-a97c-43e3-a727-2e11ff79f339)

those two fields will be automatically populated (and kept up-to-date) by listening to the Doctrine `preFlush` event. That listener (which will be called whenever we are writing something to the database), will check all the loaded entities, and update (if required) the two `pQty` / `pQtyUnlim` fields for the products (see the new `AutoUpdaterQuantitiesFromVariations` class).

In order to automatically update those two fields, users can also use:

- a new `cstore:product:quantity:update` CLI command
- a new `Automatic Product Quantity Updater` Automated Job
- a new `Automatic Product Quantity Updater` Task (for ConcreteCMS v9+)

Fix #763