### PR TITLE
Better check if we need to update product quantities

### DIFF
--- a/src/CommunityStore/Product/Product.php
+++ b/src/CommunityStore/Product/Product.php
@@ -1801,9 +1801,22 @@ class Product
 
         if ($this->hasVariations() && $variation = $this->getVariation()) {
             return $variation->isUnlimited();
-        } else {
-            return (bool) $this->pQtyUnlim;
         }
+
+        return $this->isProductUnlimited();
+    }
+
+    /**
+     * Is the actual quantity associated to the product (not to the possibly loaded variation) unlimited?
+     * The date interval won't be considered.
+     *
+     * @return bool
+     *
+     * @see \Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product::isUnlimited() you may want to use isUnlimited() instead
+     */
+    public function isProductUnlimited()
+    {
+        return (bool) $this->pQtyUnlim;
     }
 
     public function autoCheckout()
@@ -1858,9 +1871,22 @@ class Product
 
         if ($this->hasVariations() && $variation = $this->getVariation()) {
             return $variation->getStockLevel();
-        } else {
-            return $this->pQty;
         }
+
+        return $this->getProductStockLevel();
+    }
+
+    /**
+     * Get the actual quantity associated to the product, not to the possibly loaded variation.
+     * The date interval won't be considered.
+     *
+     * @return float|string|null
+     *
+     * @see \Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product::getStockLevel() you may want to use getStockLevel() instead
+     */
+    public function getProductStockLevel()
+    {
+        return $this->pQty;
     }
 
     /**

--- a/src/CommunityStore/Product/ProductVariation/ProductVariation.php
+++ b/src/CommunityStore/Product/ProductVariation/ProductVariation.php
@@ -552,7 +552,6 @@ class ProductVariation
                         'pvDisabled' => 0,
                          true, ]
                     );
-                    $product->getVariations()->add($variation);
 
                     foreach ($optioncombo as $optionvalue) {
                         $option = ProductOptionItem::getByID($optionvalue);
@@ -670,6 +669,7 @@ class ProductVariation
         $variation->setVariationWidth($data['pvWeight']);
         $variation->setVariationPackageData(isset($data['pvPackageData']) ? $data['pvPackageData'] : '');
         $variation->setVariationSort($data['pvSort']);
+        $product->getVariations()->add($variation);
         $variation->save($persistonly);
 
         return $variation;

--- a/src/CommunityStore/Utilities/AutoUpdaterQuantitiesFromVariations.php
+++ b/src/CommunityStore/Utilities/AutoUpdaterQuantitiesFromVariations.php
@@ -113,11 +113,11 @@ EOT
             }
         }
         $result = false;
-        if ($pQty !== (float) $product->getStockLevel()) {
+        if ($pQty !== (float) $product->getProductStockLevel()) {
             $product->setQty($pQty);
             $result = true;
         }
-        if ($pQtyUnlim !== (bool) $product->isUnlimited(true)) {
+        if ($pQtyUnlim !== $product->isProductUnlimited()) {
             $product->setIsUnlimited($pQtyUnlim);
             $result = true;
         }

--- a/src/CommunityStore/Utilities/DoctrineORMEventsSubscriber.php
+++ b/src/CommunityStore/Utilities/DoctrineORMEventsSubscriber.php
@@ -39,10 +39,11 @@ class DoctrineORMEventsSubscriber implements EventSubscriber
             $em = $e->getEntityManager();
             $uow = $em->getUnitOfWork();
             $products = [];
+            $entityDeletions = $uow->getScheduledEntityDeletions();
             foreach ([
                 $uow->getScheduledEntityInsertions(),
                 $uow->getScheduledEntityUpdates(),
-                $uow->getScheduledEntityDeletions(),
+                $entityDeletions,
             ] as $entities) {
                 foreach ($entities as $entity) {
                     if ($entity instanceof Product) {
@@ -60,7 +61,7 @@ class DoctrineORMEventsSubscriber implements EventSubscriber
             if ($products !== []) {
                 $class = $em->getClassMetadata(Product::class);
                 foreach ($products as $product) {
-                    if ($product->hasVariations()) {
+                    if (!in_array($product, $entityDeletions, true) && $product->hasVariations()) {
                         if ($this->service->update($product)) {
                             $uow->computeChangeSet($class, $product);
                         }

--- a/src/CommunityStore/Utilities/Installer.php
+++ b/src/CommunityStore/Utilities/Installer.php
@@ -613,7 +613,7 @@ class Installer
         $taskSetService = $app->make(TaskSetService::class);
         $taskSet = $taskSetService->getByHandle('community_store');
         if ($taskSet === null) {
-            $taskSet = $taskSetService->add('community_store', t('Community Store', $package));
+            $taskSet = $taskSetService->add('community_store', t('Community Store'), $package);
         }
         $task = $em->getRepository(Task::class)->findOneByHandle('auto_update_quantities_from_variations');
         if ($task === null) {


### PR DESCRIPTION
The `update()` method of the brand new `AutoUpdaterQuantitiesFromVariations` class checks if we need to update the product quantities.
In order to do that, we need to know the actual value of the `pQty` (and `pQtyUnlim`) of the products, without considering the possibly associated variations.
It seems to me it's impossible to to that at the moment, so I think we need two new methods (`getProductStockLevel` and `isProductUnlimited`) to retrieve these two values.

I've also added 6106689fcab0ac74bfd78b80b8d96e306d7d9e22 (a minor optimization that I forgot to add to #813).