### PR TITLE
Fix creating products with variations when "auto qty" is enabled

### DIFF
--- a/src/CommunityStore/Utilities/DoctrineORMEventsSubscriber.php
+++ b/src/CommunityStore/Utilities/DoctrineORMEventsSubscriber.php
@@ -63,7 +63,7 @@ class DoctrineORMEventsSubscriber implements EventSubscriber
                 foreach ($products as $product) {
                     if (!in_array($product, $entityDeletions, true) && $product->hasVariations()) {
                         if ($this->service->update($product)) {
-                            $uow->computeChangeSet($class, $product);
+                            $uow->recomputeSingleEntityChangeSet($class, $product);
                         }
                     }
                 }

--- a/src/CommunityStore/Utilities/DoctrineORMEventsSubscriber.php
+++ b/src/CommunityStore/Utilities/DoctrineORMEventsSubscriber.php
@@ -35,38 +35,41 @@ class DoctrineORMEventsSubscriber implements EventSubscriber
 
     public function onFlush(OnFlushEventArgs $e)
     {
-        if ($this->service->isEnabled()) {
-            $em = $e->getEntityManager();
-            $uow = $em->getUnitOfWork();
-            $products = [];
-            $entityDeletions = $uow->getScheduledEntityDeletions();
-            foreach ([
-                $uow->getScheduledEntityInsertions(),
-                $uow->getScheduledEntityUpdates(),
-                $entityDeletions,
-            ] as $entities) {
-                foreach ($entities as $entity) {
-                    if ($entity instanceof Product) {
-                        if (!in_array($entity, $products, true)) {
-                            $products[] = $entity;
-                        }
-                    } elseif ($entity instanceof ProductVariation) {
-                        $product = $entity->getProduct();
-                        if (!in_array($product, $products, true)) {
-                            $products[] = $product;
-                        }
-                    }
+        if (!$this->service->isEnabled()) {
+            return;
+        }
+        $em = $e->getEntityManager();
+        $uow = $em->getUnitOfWork();
+        $products = [];
+        $entityDeletions = $uow->getScheduledEntityDeletions();
+        foreach ([
+            $uow->getScheduledEntityInsertions(),
+            $uow->getScheduledEntityUpdates(),
+            $entityDeletions,
+        ] as $entities) {
+            foreach ($entities as $entity) {
+                if ($entity instanceof Product) {
+                    $product = $entity;
+                } elseif ($entity instanceof ProductVariation) {
+                    $product = $entity->getProduct();
+                } else {
+                    continue;
+                }
+                if (!$product->hasVariations() || in_array($product, $entityDeletions, true)) {
+                    continue;
+                }
+                if (!in_array($product, $products, true)) {
+                    $products[] = $product;
                 }
             }
-            if ($products !== []) {
-                $class = $em->getClassMetadata(Product::class);
-                foreach ($products as $product) {
-                    if (!in_array($product, $entityDeletions, true) && $product->hasVariations()) {
-                        if ($this->service->update($product)) {
-                            $uow->recomputeSingleEntityChangeSet($class, $product);
-                        }
-                    }
-                }
+        }
+        if ($products === []) {
+            return;
+        }
+        $class = $em->getClassMetadata(Product::class);
+        foreach ($products as $product) {
+            if ($this->service->update($product)) {
+                $uow->recomputeSingleEntityChangeSet($class, $product);
             }
         }
     }


### PR DESCRIPTION
When the "Calculate automatically the quantities for products with variations" option is enabled, we may encounter this error when creating a new product with variations:

```
Doctrine\DBAL\Exception\DriverException thrown with message
"An exception occurred while executing
'INSERT INTO CommunityStoreProducts
(cID, pName, pSKU, pBarcode, pDesc, pDetail, pPrice, pWholesalePrice, pCostPrice, pSalePrice, pSaleStart, pSaleEnd, pCustomerPrice, pPriceMaximum, pPriceMinimum, pPriceSuggestions, pQuantityPrice, pFeatured, pQty, pQtyUnlim, pDateAvailableStart, pDateAvailableEnd, pOutOfStockMessage, pAddToCartText, pBackOrder, pNoQty, pAllowDecimalQty, pQtySteps, pQtyLabel, pMaxQty, pTaxClass, pTaxable, pfID, pActive, pDateAdded, pDateUpdated, pShippable, pWidth, pHeight, pStackedHeight, pLength, pWeight, pNumberItems, pSeperateShip, pPackageData, pCreateUserAccount, pAutoCheckout, pOrderCompleteCID, pExclusive, pVariations, pNotificationEmails, pManufacturer, pType)
VALUES
(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
with params [0]:

SQLSTATE[HY093]: Invalid parameter number: number of bound variables does not match number of tokens"
```

(please remark the empty params).

I think the solution is to use `recomputeSingleEntityChangeSet()` instead of `computeChangeSet()` (at least this seems to fix this issue).