### PR TITLE
Update install_post.php

### DIFF
--- a/elements/dashboard/install_post.php
+++ b/elements/dashboard/install_post.php
@@ -22,7 +22,7 @@ $pkg->installStore($pkg);
 </p>
 
 <p>
-    <a class="text-primary" target="_blank" href="https://github.com/concrete5-community-store">
+    <a class="text-primary" target="_blank" href="https://github.com/concretecms-community-store">
         <?= t('View Community Store Github for additional add-ons such as payment gateways and shipping methods'); ?> <i class="fa fa-external-link-alt"></i>
     </a>
 </p>


### PR DESCRIPTION
fixed a dead link, lead to concrete5 instead of concretecms CS github