### PR TITLE
Fix Cart::add() when the product can't be found

### DIFF
--- a/src/CommunityStore/Cart/Cart.php
+++ b/src/CommunityStore/Cart/Cart.php
@@ -269,7 +269,9 @@ class Cart
 
         $customerPrice = false;
 
-        if ($product->allowCustomerPrice()) {
+        if (!$product) {
+            $error = true;
+        } elseif ($product->allowCustomerPrice()) {
             $customerPrice = (float) $data['customerPrice'];
 
             $max = $product->getPriceMaximum();
@@ -284,9 +286,6 @@ class Cart
             }
         }
 
-        if (!$product) {
-            $error = true;
-        }
 
         if (!$error) {
             if ($product->isExclusive()) {

--- a/src/CommunityStore/Cart/CartEvent.php
+++ b/src/CommunityStore/Cart/CartEvent.php
@@ -23,10 +23,10 @@ class CartEvent extends StoreEvent {
     /** @var string */
     private $errorMsg = null;
 
-    /** @var Product */
+    /** @var Product|null */
     private $product;
 
-    /** @var array | null */
+    /** @var array|null */
     private $data;
 
     private $updatedCart = null;
@@ -34,7 +34,7 @@ class CartEvent extends StoreEvent {
     private $updatedDiscounts = null;
 
     /**
-     * @return Product | null
+     * @return Product|null
      */
     public function getProduct()
     {
@@ -42,7 +42,7 @@ class CartEvent extends StoreEvent {
     }
 
     /**
-     * @param Product $product
+     * @param Product|null $product
      * @return $this
      */
     public function setProduct($product)


### PR DESCRIPTION
I see this error in the logs:

```
Call to a member function allowCustomerPrice() on null

User: Guest

URL: https://domain/cart/add

File: [webroot]/packages/community_store/src/CommunityStore/Cart/Cart.php
Line: 272
```

Let's fix it.