### PR TITLE
Add support for checking EU VAT numbers with VIES

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docs/.idea/docs.iml
 docs/.idea/modules.xml
 docs/.idea/workspace.xml
 languages
+/composer.lock

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "homepage": "https://github.com/concretecms-community-store/community_store",
     "license": "MIT",
     "require": {
-        "php": ">=7.4"
+        "php": ">=7.4",
+        "mlocati/vies": "^1.1"
     },
     "support": {
         "issues": "https://github.com/concretecms-community-store/community_store/issues",

--- a/config/vies.php
+++ b/config/vies.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'enabled' => false,
+    'applicableCountries' => [
+        // Max age (in seconds) of the cache of the list of applicable countries 
+        'cacheLifetime' => 172800, // 2 days
+    ],
+];

--- a/controller.php
+++ b/controller.php
@@ -156,6 +156,15 @@ class Controller extends Package implements ProviderAggregateInterface
         Route::register('/helpers/tax/setvatnumber', '\Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Tax::setVatNumber');
         Route::register('/productfinder', '\Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\ProductFinder::getProductMatch');
         Route::register('/store_download/{fID}/{oID}/{hash}', '\Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Download::downloadFile');
+        Route::register('/cs/dashboard/vies/status', 'Concrete\Package\CommunityStore\Controller\Dialog\ViesStatus::view');
+    }
+
+    private function registerAutoload()
+    {
+        $file = $this->getPackagePath() . '/vendor/autoload.php';
+        if (file_exists($file)) {
+            require_once $file;
+        }
     }
 
     public function registerHelpers()
@@ -179,6 +188,7 @@ class Controller extends Package implements ProviderAggregateInterface
 
     public function on_start()
     {
+        $this->registerAutoload();
         $this->registerHelpers();
         $this->registerRoutes();
         $this->registerCategories();

--- a/controllers/dialog/vies_status.php
+++ b/controllers/dialog/vies_status.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Concrete\Package\CommunityStore\Controller\Dialog;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+use Concrete\Core\Page\Page;
+use Concrete\Core\Permission\Checker;
+use Concrete\Controller\Backend\UserInterface;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Vies;
+use RuntimeException;
+
+class ViesStatus extends UserInterface
+{
+    protected $viewPath = '/dialog/vies_status';
+
+    public function view()
+    {
+        $vies = $this->app->make(Vies::class);
+        try {
+            $vowAvailable = null;
+            $this->set('countryStatuses', $vies->getCountryStatuses($vowAvailable));
+            $this->set('vowAvailable', $vowAvailable);
+            $this->set('viesError', '');
+        } catch (RuntimeException $x) {
+            $this->set('countryStatuses', []);
+            $this->set('vowAvailable', null);
+            $this->set('viesError', $x->getMessage());
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Controller\Backend\UserInterface::canAccess()
+     */
+    protected function canAccess()
+    {
+        $page = Page::getByPath('/dashboard/store/settings');
+        if (!$page || $page->isError()) {
+            return false;
+        }
+
+        $c = new Checker($page);
+        return $c->canRead();
+    }
+}

--- a/controllers/single_page/checkout.php
+++ b/controllers/single_page/checkout.php
@@ -447,13 +447,14 @@ class Checkout extends PageController
             } else {
                 $customer = new Customer();
                 $notes = '';
+                $billingAddress = false;
                 if ('billing' == $data['adrType']) {
                     $this->updateBilling($data);
                     if (isset($data['store-checkout-notes'])) {
                         $notes = $data['store-checkout-notes'];
                         Session::set('notes', $notes);
                     }
-                    $address = Session::get('billing_address');
+                    $billingAddress = $address = Session::get('billing_address');
                     $phone = Session::get('billing_phone');
                     $company = Session::get('billing_company');
                     $first_name = Session::get('billing_first_name');
@@ -473,8 +474,15 @@ class Checkout extends PageController
                     // VAT Number validation
                     if (Config::get('community_store.vat_number')) {
                         $vat_number = $customer->getValue('vat_number');
+                        if ($billingAddress === false) {
+                            $countryCode = $customer->getAddressValue('billing_address', 'country');
+                        } elseif (is_array($billingAddress)) {
+                            $countryCode = $billingAddress['country'] ?? '';
+                        } else {
+                            $countryCode = '';
+                        }
                         $taxHelper = $this->app->make(TaxHelper::class);
-                        $e = $taxHelper->validateVatNumber($vat_number);
+                        $e = $taxHelper->validateVatNumber($vat_number, $countryCode);
                         if ($e->has()) {
                             echo $e->outputJSON();
                             return;

--- a/controllers/single_page/dashboard/store/settings.php
+++ b/controllers/single_page/dashboard/store/settings.php
@@ -21,6 +21,7 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Tax\TaxClass;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\AutoUpdaterQuantitiesFromVariations;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\SalesSuspension;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Vies;
 use Punic\Currency;
 
 class Settings extends DashboardPageController
@@ -125,6 +126,8 @@ class Settings extends DashboardPageController
 
         $this->set('salesSuspension', $this->app->make(SalesSuspension::class));
         $this->set('automaticProductQuantitiesMessage', $this->buildAutomaticProductQuantitiesMessage());
+
+        $this->set('viesEnabled', $this->app->make(Vies::class)->isEnabled());
     }
 
     public function loadFormAssets()
@@ -176,6 +179,7 @@ class Settings extends DashboardPageController
                 Config::save('community_store.thousand', $args['thousand']);
                 Config::save('community_store.calculation', trim($args['calculation']));
                 Config::save('community_store.vat_number', (bool)trim($args['vat_number']));
+                $this->app->make(Vies::class)->setEnabled(!empty($args['viesEnabled']));
                 Config::save('community_store.weightUnit', $args['weightUnit']);
                 Config::save('community_store.sizeUnit', $args['sizeUnit']);
                 Config::save('community_store.deliveryInstructions', $args['deliveryInstructions'] ?? '');

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -27,6 +27,7 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
  * @var int|false|null $productPublishTarget
  * @var Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\SalesSuspension $salesSuspension
  * @var string $automaticProductQuantitiesMessage
+ * @var bool $viesEnabled
  */
 
 ?>
@@ -122,6 +123,21 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
                 <?= $form->select('vat_number', ['0' => t("No, I don't need this"), '1' => t("Yes, enable VAT Number options")], Config::get('community_store.vat_number')); ?>
             </div>
 
+            <div class="form-group">
+                <?= $form->label('viesEnabled', t('Check validity of EU VAT Numbers with VIES?')) ?>
+                <?= $form->select('viesEnabled', ['0' => t("No, I don't need this"), '1' => t('Yes, check VAT Numbers of EU countries')], $viesEnabled ? '1' : '0') ?>
+                <div class="small">
+                    <a
+                        class="dialog-launch"
+                        dialog-width="400"
+                        dialog-height="600"
+                        dialog-title="<?= t('VIES Status') ?>"
+                        href="<?= h((string) Url::to('/cs/dashboard/vies/status'))?>"
+                    >
+                        <?= t('Check VIES services status') ?> 
+                    </a>
+                </div>
+            </div>
         </div>
 
         <div class="col-sm-9 store-pane" id="settings-shipping">

--- a/src/CommunityStore/Utilities/Tax.php
+++ b/src/CommunityStore/Utilities/Tax.php
@@ -8,7 +8,7 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Customer\Customer;
 
 class Tax extends Controller
 {
-    public function validateVatNumber($vat_number)
+    public function validateVatNumber($vat_number, $countryCode = '')
     {
         $e = $this->app->make('helper/validation/error');
 
@@ -17,10 +17,24 @@ class Tax extends Controller
             return $e;
         }
 
-        // Taken from: https://www.safaribooksonline.com/library/view/regular-expressions-cookbook/9781449327453/ch04s21.html
-        $regex = "/^((AT)?U[0-9]{8}|(BE)?0[0-9]{9}|(BG)?[0-9]{9,10}|(CY)?[0-9]{8}L|(CZ)?[0-9]{8,10}|(DE)?[0-9]{9}|(DK)?[0-9]{8}|(EE)?[0-9]{9}|(EL|GR)?[0-9]{9}|(ES)?[0-9A-Z][0-9]{7}[0-9A-Z]|(FI)?[0-9]{8}|(FR)?[0-9A-Z]{2}[0-9]{9}|(GB)?([0-9]{9}([0-9]{3})?|[A-Z]{2}[0-9]{3})|(HU)?[0-9]{8}|(IE)?[0-9]S[0-9]{5}L|(IE)?[0-9]{7}[A-Z]*|(IT)?[0-9]{11}|(LT)?([0-9]{9}|[0-9]{12})|(LU)?[0-9]{8}|(LV)?[0-9]{11}|(MT)?[0-9]{8}|(NL)?[0-9]{9}B[0-9]{2}|(PL)?[0-9]{10}|(PT)?[0-9]{9}|(RO)?[0-9]{2,10}|(SE)?[0-9]{12}|(SI)?[0-9]{8}|(SK)?[0-9]{10})$/i";
+        $good = null;
+        if (is_string($countryCode)) {
+            $vies = $this->app->make(Vies::class);
+            if ($vies->isEnabled()) {
+                $good = $vies->isValid($countryCode, $vat_number);
+            }
+        }
+        if ($good === null) {
+            // Taken from: https://www.safaribooksonline.com/library/view/regular-expressions-cookbook/9781449327453/ch04s21.html
+            $regex = "/^((AT)?U[0-9]{8}|(BE)?0[0-9]{9}|(BG)?[0-9]{9,10}|(CY)?[0-9]{8}L|(CZ)?[0-9]{8,10}|(DE)?[0-9]{9}|(DK)?[0-9]{8}|(EE)?[0-9]{9}|(EL|GR)?[0-9]{9}|(ES)?[0-9A-Z][0-9]{7}[0-9A-Z]|(FI)?[0-9]{8}|(FR)?[0-9A-Z]{2}[0-9]{9}|(GB)?([0-9]{9}([0-9]{3})?|[A-Z]{2}[0-9]{3})|(HU)?[0-9]{8}|(IE)?[0-9]S[0-9]{5}L|(IE)?[0-9]{7}[A-Z]*|(IT)?[0-9]{11}|(LT)?([0-9]{9}|[0-9]{12})|(LU)?[0-9]{8}|(LV)?[0-9]{11}|(MT)?[0-9]{8}|(NL)?[0-9]{9}B[0-9]{2}|(PL)?[0-9]{10}|(PT)?[0-9]{9}|(RO)?[0-9]{2,10}|(SE)?[0-9]{12}|(SI)?[0-9]{8}|(SK)?[0-9]{10})$/i";
 
-        if ('' != $vat_number && !preg_match($regex, $vat_number)) {
+            if ('' != $vat_number && !preg_match($regex, $vat_number)) {
+                $good = false;
+            } else {
+                $good = true;
+            }
+        }
+        if ($good === false) {
             $e->add(t('You must enter a valid VAT Number'));
         }
 
@@ -36,7 +50,8 @@ class Tax extends Controller
             // VAT Number validation
             if (Config::get('community_store.vat_number')) {
                 $vat_number = str_replace(' ', '', trim($data['vat_number']));
-                $e = $this->validateVatNumber($vat_number);
+                $countryCode = $this->app->make(Customer::class)->getAddressValue('billing_address', 'country');
+                $e = $this->validateVatNumber($vat_number, $countryCode);
                 if ($e->has()) {
                     echo $e->outputJSON();
                 } else {

--- a/src/CommunityStore/Utilities/Vies.php
+++ b/src/CommunityStore/Utilities/Vies.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace Concrete\Package\CommunityStore\Src\CommunityStore\Utilities;
+
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Http\Client\Client as HttpClient;
+use MLocati\Vies\CheckStatus;
+use MLocati\Vies\CheckVat;
+use MLocati\Vies\Client as ViesClient;
+use Punic\Territory;
+use Punic\Comparer;
+use Concrete\Core\Cache\Level\ExpensiveCache;
+use MLocati\Vies\CountryCodes;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+class Vies
+{
+    private Repository $config;
+
+    private ExpensiveCache $cache;
+
+    private HttpClient $httpClient;
+
+    private LoggerInterface $logger;
+
+    private ?ViesClient $viesClient = null;
+
+    private ?array $applicableCountryCodes = null;
+
+    public function __construct(Repository $config, ExpensiveCache $cache, HttpClient $httpClient, LoggerInterface $logger)
+    {
+        $this->config = $config;
+        $this->cache = $cache;
+        $this->httpClient = $httpClient;
+    }
+
+    public function isEnabled(): bool
+    {
+        return (bool) $this->config->get('community_store::vies.enabled');
+    }
+
+    public function setEnabled(bool $value): void
+    {
+        $this->config->set('community_store::vies.enabled', $value);
+        $this->config->save('community_store::vies.enabled', $value);
+    }
+
+    /**
+     * @param string|null $iso3166CountryCode
+     * @param string|null $vatNumber
+     * @param int|null $flags the flags to be passed to CountryCodes::viesToIso3166()
+     *
+     * @return bool|null true if $vatNumber is valid; false if $vatNumber is not valid; null in case of unapplicable countries, invalid parameters, or errors.
+     */
+    public function isValid(?string $iso3166CountryCode, ?string $vatNumber, ?int $flags = 0): ?bool
+    {
+        $iso3166CountryCode = trim((string) $iso3166CountryCode);
+        if ($iso3166CountryCode === '') {
+            return null;
+        }
+        $vatNumber = trim((string) $vatNumber);
+        if ($vatNumber === '') {
+            return null;
+        }
+        try {
+            $viesCountryCode = CountryCodes::iso3166ToVies($iso3166CountryCode, $flags);
+            if ($viesCountryCode === '' || !in_array($viesCountryCode, $this->getApplicableViesCountryCodes(), true)) {
+                return null;
+            }
+            $request = new CheckVat\Request($viesCountryCode);
+            $vatNumbers = [$vatNumber];
+            $match = null;
+            if (preg_match('/^' . preg_quote($iso3166CountryCode, '/') . '-?(.+)$/', $vatNumber, $match)) {
+                array_unshift($vatNumbers, $match[1]);
+            }
+            $response = null;
+            while (count($vatNumbers) > 1) {
+                $vatNumber = array_pop($vatNumbers);
+                try {
+                    $request->setVatNumber($vatNumber);
+                    $response = $this->getViesClient()->checkVatNumber($request);
+                    if ($response->isValid() === true) {
+                        break;
+                    }
+                } catch (Throwable $_) {
+                }
+                $response = null;
+            }
+            if ($response === null) {
+                $request->setVatNumber($vatNumbers[0]);
+                $response = $this->getViesClient()->checkVatNumber($request);
+            }
+
+            return $response->isValid();
+        } catch (Throwable $x) {
+            try {
+                $this->logger->error((string) $x);
+            } catch (Throwable $_) {
+            }
+            return null;
+        }
+    }
+
+    public function getCountryStatuses(?bool &$vowAvailable = null): array
+    {
+        $status = $this->fetchViesStatus();
+        $vowAvailable = $status->getVowStatus()->isAvailable();
+        $result = [];
+        foreach ($status->getCountryCodes() as $countryCode) {
+            $countryStatus = $status->getCountryStatus($countryCode);
+            switch ($countryCode) {
+                case CountryCodes::VIES_NOTHERNIRELAND:
+                    $coutryName = Territory::getName('gbnir');
+                    break;
+                default:
+                    $coutryName = Territory::getName(CountryCodes::viesToIso3166($countryCode));
+                    break;
+            }
+            $result[] = [
+                'countryCode' => $countryCode,
+                'countryName' => $coutryName,
+                'available' => $countryStatus->isAvailable(),
+                'status' => $this->translateCountryAvailability($countryStatus->getAvailability()),
+            ];
+        }
+        $cmp = new Comparer();
+        usort(
+            $result,
+            static function (array $a, array $b) use ($cmp): int {
+                return $cmp->compare($a['countryName'], $b['countryName']);
+            }
+        );
+
+        return $result;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getApplicableViesCountryCodes(): array
+    {
+        if ($this->applicableCountryCodes === null) {
+            $cacheItem = $this->cache->getItem('cs.vies.applicable_countries');
+            if ($cacheItem->isHit()) {
+                $applicableCountryCodes = $cacheItem->get();
+                if (is_array($applicableCountryCodes)) {
+                    return $this->applicableCountryCodes = $applicableCountryCodes;
+                }
+            }
+            $this->fetchViesStatus();
+        }
+
+        return $this->applicableCountryCodes;
+    }
+
+    private function getViesClient(): ViesClient
+    {
+        if ($this->viesClient === null) {
+            if ($this->httpClient instanceof \GuzzleHttp\Client) {
+                $adapter = new \MLocati\Vies\Http\Adapter\Guzzle($this->httpClient);
+            } else {
+                $adapter = new \MLocati\Vies\Http\Adapter\Zend($this->httpClient);
+            }
+            $this->viesClient = new ViesClient($adapter);
+        }
+
+        return $this->viesClient;
+    }
+
+    private function fetchViesStatus(): CheckStatus\Response
+    {
+        $status = $this->getViesClient()->checkStatus();
+        $this->applicableCountryCodes = $status->getCountryCodes();
+        $cacheItem = $this->cache->getItem('cs.vies.applicable_countries');
+        $cacheItem
+            ->expiresAfter((int) $this->config->get('community_store::vies.applicableCountries.cacheLifetime'))
+            ->set($this->applicableCountryCodes)
+        ;
+        $this->cache->save($cacheItem);
+
+        return $status;
+    }
+
+    private function translateCountryAvailability(string $availability): string
+    {
+        switch ($availability) {
+            case CheckStatus\Response\CountryStatus::AVAILABILITY_AVAILABLE:
+                return t('Available');
+            case CheckStatus\Response\CountryStatus::AVAILABILITY_UNAVAILABLE:
+                return t('Unavailable');
+            case CheckStatus\Response\CountryStatus::AVAILABILITY_MONITORING_DISABLED:
+                return t('Monitoring disabled');
+            default:
+                return $availability;
+        }
+    }
+}

--- a/views/dialog/vies_status.php
+++ b/views/dialog/vies_status.php
@@ -1,0 +1,65 @@
+<?php
+
+defined('C5_EXECUTE') or die('Access Denied.');
+/**
+ * @var Concrete\Package\CommunityStore\Controller\Dialog\ViesStatus $controller
+ * @var Concrete\Core\View\DialogView $view
+ * @var bool|null $vowAvailable
+ * @var array[] $countryStatuses
+ * @var string $viesError
+ */
+
+if ($viesError !== '') {
+    ?>
+    <div class="alert alert-danger">
+        <?= nl2bt(h($viesError)) ?>
+    </div>
+    <?php
+}
+
+if ($vowAvailable === true) {
+    ?>
+    <div class="alert alert-success">
+        <?= t('The VIES service is currently available.') ?>
+    </div>
+    <?php
+} elseif ($vowAvailable === false) {
+    ?>
+    <div class="alert alert-danger">
+        <?= t('The VIES service is currently NOT available.') ?>
+    </div>
+    <?php
+}
+if ($countryStatuses !== []) {
+    ?>
+    <table class="table table-sm caption-top">
+        <colgroup>
+            <col width="1" />
+        </colgroup>
+        <caption>
+            <?= t('Country-specific states')?>
+        </caption>
+        <tbody>
+            <?php
+            foreach ($countryStatuses as $countryStatus) {
+                ?>
+                <tr>
+                    <th>
+                        <code><?= h($countryStatus['countryCode'])?></code>
+                    </th>
+                    <th>
+                        <?= h($countryStatus['countryName']) ?>
+                    </th>
+                    <td>
+                        <span class="<?= $countryStatus['available'] ? 'text-success' : 'text-danger' ?>">
+                            <?= h($countryStatus['status']) ?>
+                        </span>
+                    </td>
+                </tr>
+                <?php
+            }
+            ?>
+        </tbody>
+    </table>
+    <?php
+}


### PR DESCRIPTION
When we ask for VAT numbers, we check that they are syntactically correct (for example, in Italy we use 11 digits).

But it may not be enough: even if a VAT number is syntactically correct, it may be wrong.

What about checking for actual validity of VAT numbers for European countries? We can use the great [VIES service](https://ec.europa.eu/taxation_customs/vies) 😉