### PR TITLE
Make Multilingual utility a singleton

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -170,15 +170,20 @@ class Controller extends Package implements ProviderAggregateInterface
     public function registerHelpers()
     {
         $singletons = [
-            'cs/helper/multilingual' => '\Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Multilingual',
+            'Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Multilingual' => [
+                'cs/helper/multilingual',
+            ]
         ];
 
         $binds = [
             'cs/helper/image' => '\Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image',
         ];
 
-        foreach ($singletons as $key => $value) {
-            $this->app->singleton($key, $value);
+        foreach ($singletons as $key => $aliases) {
+            $this->app->singleton($key);
+            foreach ($aliases as $alias) {
+                $this->app->alias($key, $alias);
+            }
         }
 
         foreach ($binds as $key => $value) {


### PR DESCRIPTION
With

```php
$app->singleton('cs/helper/multilingual', Utilities\Multilingual::class);
```

we make `'cs/helper/multilingual'` a singleton, but `Utilities\Multilingual` is not a singleton (which is not good for Dependency Injection).

What about making `Utilities\Multilingual` a singleton and `'cs/helper/multilingual'` an alias of it?

```php
$app->singleton(Utilities\Multilingual::class);
$app->alias('cs/helper/multilingual', Utilities\Multilingual::class);
```

