### PR TITLE
Add an option to add OpenGraph meta tags to product pages

### DIFF
--- a/config/products.php
+++ b/config/products.php
@@ -11,4 +11,10 @@ return [
             'title' => 'keep',
         ],
     ],
+    'pages' => [
+        'metadata' => [
+            'updateDescription' => true,
+            'updateOpenGraph' >= false,
+        ],
+    ],
 ];

--- a/controller.php
+++ b/controller.php
@@ -274,6 +274,7 @@ class Controller extends Package implements ProviderAggregateInterface
                 $app->add(new Src\CommunityStore\Console\Command\ResetCommand());
                 $app->add(new Src\CommunityStore\Console\Command\AutoUpdateQuantitiesFromVariations());
                 $app->add(new Src\CommunityStore\Console\Command\AutoUpdateProductImageInfo());
+                $app->add(new Src\CommunityStore\Console\Command\AutoUpdateProductPageMetadata());
             } catch (\Exception $e) {
             }
         }

--- a/controllers/single_page/dashboard/store/products.php
+++ b/controllers/single_page/dashboard/store/products.php
@@ -34,6 +34,7 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductType\Produ
 use Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductOption\ProductOption;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductVariation\ProductVariation;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\ProductImageInfoUpdater;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\ProductPageMetadataUpdater;
 
 class Products extends DashboardSitePageController
 {
@@ -550,6 +551,9 @@ class Products extends DashboardSitePageController
 
                 $imageUpdater = $this->app->make(ProductImageInfoUpdater::class);
                 $imageUpdater->applyToProduct($product);
+
+                $pageUpdater = $this->app->make(ProductPageMetadataUpdater::class);
+                $pageUpdater->applyToProduct($product);
 
                 //$product->reindex();
 

--- a/controllers/single_page/dashboard/store/settings.php
+++ b/controllers/single_page/dashboard/store/settings.php
@@ -22,6 +22,7 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\AutoUpdaterQuan
 use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\OnlineVATChecker;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\ProductImageInfoUpdater;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\ProductPageMetadataUpdater;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\SalesSuspension;
 use Punic\Currency;
 
@@ -130,6 +131,7 @@ class Settings extends DashboardPageController
 
         $this->set('checkVatsOnline', $this->app->make(OnlineVATChecker::class)->isEnabled());
         $this->set('productImageInfoUpdater', $this->app->make(ProductImageInfoUpdater::class));
+        $this->set('productPageMetadataUpdater', $this->app->make(ProductPageMetadataUpdater::class));
     }
 
     public function loadFormAssets()
@@ -315,6 +317,9 @@ class Settings extends DashboardPageController
                 ;
                 $productImageInfoUpdater = $this->app->make(ProductImageInfoUpdater::class);
                 $productImageInfoUpdater->setTitleOperation(is_string($args['autoImageUpdate_title'] ?? null) ? $args['autoImageUpdate_title'] : '');
+                $productPageMetadataUpdater = $this->app->make(ProductPageMetadataUpdater::class);
+                $productPageMetadataUpdater->setIsUpdateDescription(!empty($args['updatePageMetadata_description']));
+                $productPageMetadataUpdater->setIsUpdateOpenGraph(!empty($args['updatePageMetadata_opengraph']));
 
                 $this->flash('success', t('Settings Saved'));
 

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -5,6 +5,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 use Concrete\Core\Support\Facade\Config;
 use Concrete\Core\Support\Facade\Url;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Console\Command\AutoUpdateProductImageInfo;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Console\Command\AutoUpdateProductPageMetadata;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\AutoUpdaterQuantitiesFromVariations;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
 
@@ -30,6 +31,7 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
  * @var string $automaticProductQuantitiesMessage
  * @var bool $checkVatsOnline
  * @var Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\ProductImageInfoUpdater $productImageInfoUpdater
+ * @var Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\ProductPageMetadataUpdater $productPageMetadataUpdater
  */
 
 ?>
@@ -447,6 +449,26 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
             <div class="form-group">
                 <?= $form->label('productPublishTarget', t('Page to Publish Product Pages Under')); ?>
                 <?= $pageSelector->selectPage('productPublishTarget', $productPublishTarget); ?>
+            </div>
+
+            <div class="form-group">
+                <?= $form->label('', t('Product pages automatic update')) ?>
+                <div class="checkbox">
+                    <label>
+                        <?= $form->checkbox('updatePageMetadata_description', '1', $productPageMetadataUpdater->isUpdateDescription()) ?>
+                        <?= t('Update the page description') ?>
+                    </label>
+                </div>
+                <div class="checkbox">
+                    <label>
+                        <?= $form->checkbox('updatePageMetadata_opengraph', '1', $productPageMetadataUpdater->isUpdateOpenGraph()) ?>
+                        <?= t('Update the page OpenGraph metadata (useful for sharing pages on social networks') ?>
+                        <span class="small text-muted">
+                            <br />
+                            <?= t('You can update the existing product pages by using the %s CLI command.', '<code>' . AutoUpdateProductPageMetadata::NAME . '</code>') ?></li>
+                        </span>
+                    </label>
+                </div>
             </div>
 
             <div class="form-group">

--- a/src/CommunityStore/Console/Command/AutoUpdateProductPageMetadata.php
+++ b/src/CommunityStore/Console/Command/AutoUpdateProductPageMetadata.php
@@ -1,0 +1,204 @@
+<?php
+declare(strict_types=1);
+
+namespace Concrete\Package\CommunityStore\Src\CommunityStore\Console\Command;
+
+use Concrete\Core\Error\UserMessageException;
+use Concrete\Core\Site\Service as SiteService;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\ProductPageMetadataUpdater;
+use Doctrine\ORM\EntityManagerInterface;
+use Generator;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+class AutoUpdateProductPageMetadata extends Command
+{
+    const NAME = 'cstore:product:page:metadata:update';
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Symfony\Component\Console\Command\Command::configure()
+     */
+    protected function configure()
+    {
+        $app = app();
+        $updater = $app->make(ProductPageMetadataUpdater::class);
+        $flags = $updater->getDefaultFlags();
+        $defaultFlags = [];
+        foreach (array_keys($updater->getFlagsDictionary()) as $flag) {
+            $flag = (int) $flag;
+            if (($flags & $flag) === $flag) {
+                $defaultFlags[] = $flag;
+            }
+        }
+        $this
+            ->setName(static::NAME)
+            ->setDescription('Update the metadata of the product pages')
+            ->addOption('flags', 'f', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Flags identifying what should be updated', $defaultFlags)
+            ->addOption('all', 'a', InputOption::VALUE_NONE, 'Update all the products')
+            ->addOption('product', 'p', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Limit the execution only for the specific product ID(s)')
+            ->addOption('yes', 'y', InputOption::VALUE_NONE, 'Execute the operation without confirmation')
+        ;
+        $lines = [];
+        $lines[] = sprintf('Allowed values of the %s option are:', '--flags');
+        foreach ($updater->getFlagsDictionary() as $key => $name) {
+            $lines[] = "- {$key}: {$name}";
+        }
+        $this->setHelp(implode("\n", $lines));
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Symfony\Component\Console\Command\Command::execute()
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $app = app();
+        $updater = $app->make(ProductPageMetadataUpdater::class);
+        $em = $app->make(EntityManagerInterface::class);
+        try {
+            $flags = $this->resolveFlags($input, $updater);
+            $products = $this->resolveProducts($input, $em);
+            if (!$this->confirmOperation($input, $output, $updater, $flags, $products)) {
+                return 0;
+            }
+            $totalUpdated = 0;
+            foreach ($this->listProducts($products, $em) as $product) {
+                $output->write(sprintf('Updating product with ID %s... ', $product->getID()));
+                try {
+                    $numUpdated = $updater->applyToProduct($product, $flags);
+                } catch (UserMessageException $x) {
+                    $output->writeln("<error>{$x->getMessage()}</error>");
+                    continue;
+                }
+                $output->writeln(sprintf("<info>done (pages updated: %s).</info>", $numUpdated));
+                $totalUpdated += $numUpdated;
+            }
+            $output->writeln('');
+            $output->writeln(sprintf('Total number of pages updated: %s', $totalUpdated));
+        } catch (UserMessageException $x) {
+            $output->writeln("<error>{$x->getMessage()}</error>");
+            return 1;
+        }
+        return 0;
+    }
+
+    /**
+     * @throws \Concrete\Core\Error\UserMessageException
+     */
+    protected function resolveFlags(InputInterface $input, ProductPageMetadataUpdater $updater): int
+    {
+        $allPrettyUrlsConfigured = true;
+        $siteService = app(SiteService::class);
+        foreach ($siteService->getList() as $site) {
+            if (!$site->getConfigRepository()->get('seo.canonical_url')) {
+                $allPrettyUrlsConfigured = false;
+            }
+        }
+        $flags = 0;
+        $dictionary = $updater->getFlagsDictionary();
+        foreach ($input->getOption('flags') as $flag) {
+            if (is_numeric($flag)) {
+                $flag = (int) $flag;
+                if (array_key_exists($flag, $dictionary)) {
+                    switch ($flag) {
+                        case $updater::FLAG_UPDATE_OPENGRAPH:
+                            if (!$allPrettyUrlsConfigured) {
+                                throw new UserMessageException('In order to set the OpenGraph meta tags you need to configure the website canonical URL');
+                            }
+                    }
+                    $flags = $flags | $flag;
+                    continue;
+                }
+            }
+            $lines = [];
+            $lines[] = sprintf('%1$s is not a valid value for the %2$s option.', $flag, '--flag');
+            $lines[] = '';
+            $lines[] = sprintf('Allowed values of the %s option are:', '--flag');
+            foreach ($dictionary as $key => $name) {
+                $lines[] = "- {$key}: {$name}";
+            }
+            throw new UserMessageException(implode("\n", $lines));
+        }
+        if ($flags === 0) {
+            throw new UserMessageException('Please specify at least one flag');
+        }
+
+        return $flags;
+    }
+
+    protected function resolveProducts(InputInterface $input, EntityManagerInterface $em): array
+    {
+        $productIDs = $input->getOption('product');
+        if ($input->getOption('all') === ($productIDs !== [])) {
+            throw new UserMessageException('Please specify the products pages to be updated (--product option), or --all to update all product pages.');
+        }
+        if ($input->getOption('all')) {
+            return [];
+        }
+        $products = [];
+        foreach ($productIDs as $productID) {
+            if (is_numeric($productID)) {
+                $productID = (int) $productID;
+                if (isset($products[$productID])) {
+                    continue;
+                }
+                $product = $em->find(Product::class, $productID);
+                if ($product !== null) {
+                    $products[$productID] = $product;
+                    continue;
+                }
+            }
+            throw new UserMessageException(sprintf('Unable to find a product with ID %s', $productID));
+        }
+        return array_values($products);
+    }
+
+    protected function confirmOperation(InputInterface $input, OutputInterface $output, ProductPageMetadataUpdater $updater, int $flags, array $products): bool
+    {
+        if (!$output->isQuiet()) {
+            $table = new Table($output);
+            foreach ($updater->getFlagsDictionary() as $flag => $name) {
+                $flag = (int) $flag;
+                $flagSelected = ($flags & $flag) === $flag;
+                $table->addRow([$name, $flagSelected ? 'yes' : 'no']);
+            }
+            $table->addRow(['Products', $products === [] ? 'all' : sprintf('%s product(s) specified', count($products))]);
+            $table->render();
+        }
+        if ($input->getOption('yes')) {
+            return true;
+        }
+        if (!$input->isInteractive()) {
+            throw new UserMessageException('In non-interactive mode you have to specify the --yes option');
+        }
+        $question = new ConfirmationQuestion(
+            'Proceed with the automatic update? (y/n) ',
+            false
+        );
+        return $this->getHelper('question')->ask($input, $output, $question);
+    }
+
+    protected function listProducts(array $products, EntityManagerInterface $em): Generator
+    {
+        if ($products !== []) {
+            foreach ($products as $product) {
+                yield $product;
+            }
+            return;
+        }
+        $repo = $em->getRepository(Product::class);
+        foreach ($repo->findAll() as $product) {
+            yield $product;
+        }
+    }
+}

--- a/src/CommunityStore/Product/Product.php
+++ b/src/CommunityStore/Product/Product.php
@@ -1060,7 +1060,6 @@ class Product
         if ($data['pID']) {
             //if we know the pID, we're updating.
             $product = self::getByID($data['pID']);
-            $product->setPageDescription($data['pDesc']);
 
             if ($data['pDateAdded_dt']) {
                 $product->setDateAdded(new \DateTime($data['pDateAdded_dt'] . ' ' . $data['pDateAdded_h'] . ':' . $data['pDateAdded_m'] . (isset($data['pDateAdded_a']) ? $data['pDateAdded_a'] : '')));
@@ -2238,7 +2237,6 @@ class Product
                     $newProductPage->setAttribute('exclude_nav', 1);
 
                     $this->savePageID($newProductPage->getCollectionID());
-                    $this->setPageDescription($this->getDesc());
 
                     $csm = $app->make('cs/helper/multilingual');
                     $mlist = Section::getList();
@@ -2256,13 +2254,6 @@ class Product
 
                                 if ($productName) {
                                     $translatedPage->update(['cName' => $productName]);
-                                }
-
-                                $pageDescription = trim($translatedPage->getAttribute('meta_description'));
-                                $newDescription = $csm->t(null, 'productDescription', $this->getID(), false, $m->getLocale());
-
-                                if ($newDescription && !$pageDescription) {
-                                    $translatedPage->setAttribute('meta_description', strip_tags($newDescription));
                                 }
                             }
                         }
@@ -2289,6 +2280,9 @@ class Product
         }
     }
 
+    /**
+     * @deprecated see \Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\ProductPageMetadataUpdater
+     */
     public function setPageDescription($newDescription)
     {
         $productDescription = strip_tags(trim($this->getDesc()));

--- a/src/CommunityStore/Utilities/ProductPageMetadataUpdater.php
+++ b/src/CommunityStore/Utilities/ProductPageMetadataUpdater.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Package\CommunityStore\Src\CommunityStore\Utilities;
+
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Entity\File\File;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Multilingual\Page\Section\Section;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product;
+use Generator;
+
+class ProductPageMetadataUpdater
+{
+    public const FLAG_UPDATE_DESCRIPTION = 0b1;
+    public const FLAG_UPDATE_OPENGRAPH = 0b10;
+
+    private ResolverManagerInterface $urlResolver;
+    private Repository $config;
+    private Multilingual $multilingual;
+
+    public function __construct(
+        ResolverManagerInterface $urlResolver,
+        Repository $config,
+        Multilingual $multilingual
+    )
+    {
+        $this->urlResolver = $urlResolver;
+        $this->config = $config;
+        $this->multilingual = $multilingual;
+    }
+
+    public function isUpdateDescription(): bool
+    {
+        return (bool) $this->config->get('community_store::products.pages.metadata.updateDescription');
+    }
+
+    public function setIsUpdateDescription(bool $value): void
+    {
+        $this->config->set('community_store::products.pages.metadata.updateDescription', $value);
+        $this->config->save('community_store::products.pages.metadata.updateDescription', $value);
+    }
+
+    public function isUpdateOpenGraph(): bool
+    {
+        return (bool) $this->config->get('community_store::products.pages.metadata.updateOpenGraph');
+    }
+
+    public function setIsUpdateOpenGraph(bool $value): void
+    {
+        $this->config->set('community_store::products.pages.metadata.updateOpenGraph', $value);
+        $this->config->save('community_store::products.pages.metadata.updateOpenGraph', $value);
+    }
+
+    public function getFlagsDictionary(): array
+    {
+        return [
+            static::FLAG_UPDATE_DESCRIPTION => t('Update page descriptions'),
+            static::FLAG_UPDATE_OPENGRAPH => t('Update page OpenGraph meta tags'),
+        ];
+    }
+
+    public function getDefaultFlags(): int
+    {
+        return 0
+            | ($this->isUpdateDescription() ? static::FLAG_UPDATE_DESCRIPTION : 0)
+            | ($this->isUpdateOpenGraph() ? static::FLAG_UPDATE_OPENGRAPH : 0)
+        ;
+    }
+
+    /**
+     * @param int|null $flags use NULL to use the configured flags
+     *
+     * @return int the number of pages that have been updated
+     */
+    public function applyToProduct(Product $product, ?int $flags = null): int
+    {
+        if ($flags === null) {
+            $flags = $this->getDefaultFlags();
+        }
+        if ($flags === 0) {
+            return 0;
+        }
+        $numPagesUpdated = 0;
+        foreach ($this->getProductPages($product) as [$page, $section]) {
+            $pageUpdated = false;
+            if (($flags & static::FLAG_UPDATE_DESCRIPTION) === static::FLAG_UPDATE_DESCRIPTION) {
+                if ($this->updatePageDescription($product, $page, $section)) {
+                    $pageUpdated = true;
+                }
+            }
+            if (($flags & static::FLAG_UPDATE_OPENGRAPH) === static::FLAG_UPDATE_OPENGRAPH) {
+                if ($this->updatePageOpenGraph($product, $page, $section)) {
+                    $pageUpdated = true;
+                }
+            }
+            if ($pageUpdated) {
+                $numPagesUpdated++;
+            }
+        }
+
+        return $numPagesUpdated;
+    }
+
+    private function getProductPages(Product $product): Generator
+    {
+        $page = Page::getByID($product->getPageID());
+        if (!$page || $page->isError() || $page->isInTrash()) {
+            return;
+        }
+        yield [$page, null];
+        $doneIDs = [(int) $page->getCollectionID()];
+        foreach (Section::getList($page->getSite()) as $section) {
+            $translatedPageID = $section->getTranslatedPageID($page);
+            if (!$translatedPageID) {
+                continue;
+            }
+            $translatedPageID = (int) $translatedPageID;
+            if (in_array($translatedPageID, $doneIDs, true)) {
+                continue;
+            }
+            $doneIDs[] = $translatedPageID;
+            $translatedPage = Page::getByID($translatedPageID);
+            if (!$translatedPage || $translatedPage->isError() || $translatedPage->isInTrash()) {
+                continue;
+            }
+            yield [$translatedPage, $section];
+        }
+    }
+
+    private function updatePageDescription(Product $product, Page $page, ?Section $section): bool
+    {
+        $newDescription = implode(' ', $this->getProductDescriptionLines($product, $section));
+        if ($newDescription === '') {
+            return false;
+        }
+        $oldDescription = trim((string) $page->getAttribute('meta_description'));
+        if ($newDescription === $oldDescription) {
+            return false;
+        }
+        $page->setAttribute('meta_description', $newDescription);
+
+        return true;
+    }
+
+    private function updatePageOpenGraph(Product $product, Page $page, ?Section $section): bool
+    {
+        $oldHeaders = (string) $page->getAttribute('header_extra_content');
+        $newHeaders = $oldHeaders;
+        foreach ($this->generateOpenGraphTags($page, $product, $section) as [$rxSearch, $newTag]) {
+            $newHeaders = preg_replace($rxSearch, '', $newHeaders);
+            if ($newTag !== '') {
+                $newHeaders = rtrim($newHeaders);
+                if ($newHeaders === '') {
+                    $newHeaders = $newTag;
+                } else {
+                    $newHeaders .= "\n" . $newTag;
+                }
+            }
+        }
+        $newHeaders = trim($newHeaders);
+        if ($newHeaders !== '') {
+            $newHeaders .= "\n";
+        }
+        if ($newHeaders === $oldHeaders) {
+            return false;
+        }
+        $page->setAttribute('header_extra_content', $newHeaders);
+
+        return true;
+    }
+
+    private function generateOpenGraphTags(Page $page, Product $product, ?Section $section): array
+    {
+        $name = $this->getProductName($product, $section);
+        $description = implode(' ', array_slice($this->getProductDescriptionLines($product, $section), 0, 2));
+        $price = $this->getProductPrice($product);
+        $imageUrl = $this->getProductImageUrl($product);
+        if ($section === null) {
+            $pageSection = Section::getBySectionOfSite($page);
+            $localeID = $pageSection ? (string) $pageSection->getLocale() : '';
+        } else {
+            $localeID = (string) $section->getLocale();
+        }
+        $site = $page->getSite();
+        $siteName = $site ? (string) $site->getSiteName() : '';
+
+        $buildItem = static function(string $property, string $content): array {
+            return [
+                '/<meta\b[^>]*\bproperty\s*=\s*["\']?' . preg_quote($property, '/') . '\b((\s*>)|(["\'\s][^>]*>))(\s*($|[\r\n]+))?/i',
+                $content === '' ? '' : "<meta property=\"{$property}\" content=\"{$content}\" />",
+            ];
+        };
+
+        return [
+            $buildItem('og:type', 'product'),
+            $buildItem('og:url', h((string) $this->urlResolver->resolve([$page]))),
+            $buildItem('og:title', h($name)),
+            $buildItem('og:description', h($description)),
+            $buildItem('og:locale', h($localeID)),
+            $buildItem('og:site_name', h($siteName)),
+            $buildItem('og:product:amount', h($price)),
+            $buildItem('og:product:currency', $price === '' ? '' : h($this->config->get('community_store.currency'))),
+            $buildItem('og:image', h($imageUrl)),
+            $buildItem('og:image:alt', $imageUrl === '' ? '' : h($name)),
+        ];
+    }
+
+    private function getProductName(Product $product, ?Section $section): string
+    {
+        if ($section === null) {
+            return (string) $product->getName();
+        }
+
+        return (string) $this->multilingual->t(null, 'productName', $product->getID(), false, $section->getLocale());
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getProductDescriptionLines(Product $product, ?Section $section): array
+    {
+        if ($section === null) {
+            $text = (string) $product->getDescription();
+        } else {
+            $text = (string) $this->multilingual->t(null, 'productDescription', $product->getID(), false, $section->getLocale());
+        }
+        $text = preg_replace('/\s+/', ' ', $text);
+        $text = preg_replace('_(<(br|/p|/div|/td)\b.*?>)_i', "\\1\n", $text);
+        $lines = [];
+        foreach (preg_split('/\s*\n\s*/', $text, -1, PREG_SPLIT_NO_EMPTY) as $line) {
+            $line = trim(html_entity_decode(strip_tags($line)));
+            if ($line !== '') {
+                $lines[] = preg_replace('/  +/', ' ', $line);
+            }
+        }
+
+        return $lines;
+    }
+
+    private function getProductPrice(Product $product): string
+    {
+        return (string) $product->getActivePrice();
+    }
+
+    private function getProductImageUrl(Product $product): string
+    {
+        if (($url = $this->resolveProductImageUrl($product->getImageObj())) !== '') {
+            return $url;
+        }
+        foreach ($product->getimagesobjects() as $file) {
+            if (($url = $this->resolveProductImageUrl($file)) !== '') {
+                return $url;
+            }
+        }
+        foreach ($product->getVariations() as $variation) {
+            if (($url = $this->resolveProductImageUrl($variation->getVariationImageObj())) !== '') {
+                return $url;
+            }
+        }
+
+        return '';
+    }
+
+    private function resolveProductImageUrl(?File $file): string
+    {
+        $version = $file === null ? null : $file->getApprovedVersion();
+        if ($version === null) {
+            return '';
+        }
+
+        return $version->getURL() ?? '';
+    }
+}


### PR DESCRIPTION
What about adding [OpenGraph metadata tags](https://ogp.me/) meta tags to product pages?

This improve the display of product pages when shared on social networks.

For example, pages shared on Facebook now show the product pictures (without the opengraph tags, Facebook picks the first image found on the page, which is the website logo in my case).

Here's a sample set of meta tags automatically added to the `header_extra_content` page attribute:

```html
<meta property="og:type" content="product" />
<meta property="og:url" content="https://www.example.com/products/my-product" />
<meta property="og:title" content="My Product Name" />
<meta property="og:description" content="This is the product description." />
<meta property="og:locale" content="en_US" />
<meta property="og:site_name" content="My Site Name" />
<meta property="og:product:amount" content="123" />
<meta property="og:product:currency" content="EUR" />
<meta property="og:image" content="https://www.example.com/application/files/1234/5678/9012/image.jpg" />
<meta property="og:image:alt" content="My Product Name" />
```
