### PR TITLE
Minor fixes for #869

### DIFF
--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -462,10 +462,10 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
                 <div class="checkbox">
                     <label>
                         <?= $form->checkbox('updatePageMetadata_opengraph', '1', $productPageMetadataUpdater->isUpdateOpenGraph()) ?>
-                        <?= t('Update the page OpenGraph metadata (useful for sharing pages on social networks') ?>
+                        <?= t('Update the page OpenGraph metadata (useful for sharing pages on social networks)') ?>
                         <span class="small text-muted">
                             <br />
-                            <?= t('You can update the existing product pages by using the %s CLI command.', '<code>' . AutoUpdateProductPageMetadata::NAME . '</code>') ?></li>
+                            <?= t('You can update the existing product pages by using the %s CLI command.', '<code>' . AutoUpdateProductPageMetadata::NAME . '</code>') ?>
                         </span>
                     </label>
                 </div>

--- a/src/CommunityStore/Utilities/ProductPageMetadataUpdater.php
+++ b/src/CommunityStore/Utilities/ProductPageMetadataUpdater.php
@@ -6,6 +6,7 @@ namespace Concrete\Package\CommunityStore\Src\CommunityStore\Utilities;
 
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Entity\File\File;
+use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Multilingual\Page\Section\Section;
 use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
@@ -174,6 +175,10 @@ class ProductPageMetadataUpdater
 
     private function generateOpenGraphTags(Page $page, Product $product, ?Section $section): array
     {
+        $pageUrl = (string) $this->urlResolver->resolve([$page]);
+        if (!filter_var($pageUrl, FILTER_VALIDATE_URL)) {
+        	$pageUrl = '';
+        }
         $name = $this->getProductName($product, $section);
         $description = implode(' ', array_slice($this->getProductDescriptionLines($product, $section), 0, 2));
         $price = $this->getProductPrice($product);
@@ -196,7 +201,7 @@ class ProductPageMetadataUpdater
 
         return [
             $buildItem('og:type', 'product'),
-            $buildItem('og:url', h((string) $this->urlResolver->resolve([$page]))),
+            $buildItem('og:url', h($pageUrl)),
             $buildItem('og:title', h($name)),
             $buildItem('og:description', h($description)),
             $buildItem('og:locale', h($localeID)),


### PR DESCRIPTION
In addition to a couple of typos in the settings page, with this PR we make sure we won't create `og:url` meta tags with invalid values (this may occur if the pretty URL is not set and we use a CLI command)