### PR TITLE
Fix "Undefined array key" in Cart::update()

### DIFF
--- a/src/CommunityStore/Cart/Cart.php
+++ b/src/CommunityStore/Cart/Cart.php
@@ -554,7 +554,7 @@ class Cart
 
         $cart = self::getCart();
 
-        $product = Product::getByID((int) $cart[$instanceID]['product']['pID']);
+        $product = empty($cart[$instanceID]['product']['pID']) ? null : Product::getByID((int) $cart[$instanceID]['product']['pID']);
         $event = new CartEvent('update');
         $event->setProduct($product);
         $event->setData($data);


### PR DESCRIPTION
I've been notified by [this nice addon of mine](https://marketplace.concretecms.com/marketplace/addons/error-notifier) about this error:

```
Undefined array key 1

User: Guest

URL: https://www.domain.com/cart

File: [webroot]/packages/community_store/src/CommunityStore/Cart/Cart.php
Line: 557

Trace:
#0 [webroot]/packages/community_store/src/CommunityStore/Cart/Cart.php(557): Whoops\Run->handleError()
#1 [webroot]/packages/community_store/src/CommunityStore/Cart/Cart.php(542): Concrete\Package\CommunityStore\Src\CommunityStore\Cart\Cart::update()
#2 [webroot]/packages/community_store/controllers/single_page/cart.php(58): Concrete\Package\CommunityStore\Src\CommunityStore\Cart\Cart::updateMultiple()
#3 [internal function]: Concrete\Package\CommunityStore\Controller\SinglePage\Cart->view()
```

Let's fix this warning.