### PR TITLE
Fix "Undefined variable $added" in Cart::update()

### DIFF
--- a/src/CommunityStore/Cart/Cart.php
+++ b/src/CommunityStore/Cart/Cart.php
@@ -585,6 +585,7 @@ class Cart
             $added = $newquantity;
         } else {
             self::remove($instanceID);
+            $added = null;
         }
 
         Session::set('communitystore.cart', $cart);


### PR DESCRIPTION
Another fix, now for this warning:

```
Undefined variable $added

User: Guest

URL: https://www.domain.com/cart/update

File: [webroot]/packages/community_store/src/CommunityStore/Cart/Cart.php
Line: 597

Trace:
#0 [webroot]/packages/community_store/src/CommunityStore/Cart/Cart.php(597): Whoops\Run->handleError()
#1 [webroot]/packages/community_store/src/CommunityStore/Cart/Cart.php(542): Concrete\Package\CommunityStore\Src\CommunityStore\Cart\Cart::update()
#2 [webroot]/packages/community_store/controllers/single_page/cart.php(198): Concrete\Package\CommunityStore\Src\CommunityStore\Cart\Cart::updateMultiple()
#3 [internal function]: Concrete\Package\CommunityStore\Controller\SinglePage\Cart->update()
```
