### PR TITLE
Don't show Guest group in allowed/disallowed groups for payment methods

### DIFF
--- a/controllers/single_page/dashboard/store/settings.php
+++ b/controllers/single_page/dashboard/store/settings.php
@@ -57,6 +57,10 @@ class Settings extends DashboardPageController
 
         $gl->includeAllGroups();
         foreach ($gl->getResults() as $group) {
+            if ($group->getGroupID() == GUEST_GROUP_ID) {
+                // Even registered users belong to the Guests group
+                continue;
+            }
             $allGroupList[$group->getGroupID()] = $group->getGroupName();
         }
 


### PR DESCRIPTION
I'm working on the code of a payment method.

In order to test it in the production website. I wanted to prevent non registered users from using it.

For that reason, I've added the Guests to the "Exclude From User Groups" settings.
But with that settings, even administrators weren't seeing the payment method.

The reason? Every site visitor is a member of the Guest user group (yep, both registered and not registered users) - [see here](https://github.com/concretecms/concretecms/blob/9.3.1/concrete/src/User/User.php#L739).

So, choosing "Guests" actually means "Always", but it's really misleading.

What about simply removing "Guests"?