### PR TITLE
Explicitly declare that the superuser is in the administrators group

### DIFF
--- a/src/CommunityStore/Payment/Method.php
+++ b/src/CommunityStore/Payment/Method.php
@@ -277,6 +277,9 @@ class Method extends Controller
 
         $u = app(User::class);
         $userGroups = $u->getUserGroups();
+        if ($u->isSuperUser()) {
+            $userGroups[ADMIN_GROUP_ID] = ADMIN_GROUP_ID;
+        }
 
         foreach ($enabledMethods as $em) {
             $includedGroups = $em->getUserGroups();

--- a/src/CommunityStore/Payment/Method.php
+++ b/src/CommunityStore/Payment/Method.php
@@ -285,11 +285,11 @@ class Method extends Controller
             $includedGroups = $em->getUserGroups();
             $excludedGroups = $em->getExcludedUserGroups();
 
-            if (count($includedGroups) > 0 && count(array_intersect($includedGroups, $userGroups)) == 0) {
+            if ($includedGroups !== [] && array_intersect($includedGroups, $userGroups) === []) {
                 continue;
             }
 
-            if (count($excludedGroups) > 0 && count(array_intersect($excludedGroups, $userGroups)) > 0) {
+            if ($excludedGroups !== [] && array_intersect($excludedGroups, $userGroups) !== []) {
                 continue;
             }
 


### PR DESCRIPTION
The superuser implicitly belongs to the the administrators group: the core doesn't set it.

You can try it: if you login as `admin` and check the value of  `app(\Concrete\Core\User\User::class)->getUserGroups()` you'll see that the group ids are `1` (`GUEST_GROUP_ID`) and `2` (`REGISTERED_GROUP_ID`), but not `3` (`ADMIN_GROUP_ID`).
