### PR TITLE
Add payment methods logs viewer

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -25,7 +25,7 @@ class Controller extends Package implements ProviderAggregateInterface
 {
     protected $pkgHandle = 'community_store';
     protected $appVersionRequired = '8.5';
-    protected $pkgVersion = '2.6.5-alpha2';
+    protected $pkgVersion = '2.6.5-alpha3';
 
     protected $npmPackages = [
         'sysend' => '1.3.4',

--- a/controllers/single_page/dashboard/store/reports/payments.php
+++ b/controllers/single_page/dashboard/store/reports/payments.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Package\CommunityStore\Controller\SinglePage\Dashboard\Store\Reports;
+
+use Concrete\Core\Error\UserMessageException;
+use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Localization\Localization;
+use Concrete\Core\Localization\Service\Date;
+use Concrete\Core\Page\Controller\DashboardPageController;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Payment\LogEntry;
+use Concrete\Package\CommunityStore\Src\CommunityStore\Payment\LogProviderFactory;
+use DateInterval;
+use DateTimeImmutable;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+class Payments extends DashboardPageController
+{
+    public function view(): void
+    {
+        $this->addHeaderItem(<<<'EOT'
+<style>
+[v-cloak] {
+    display: none;
+}
+</style>
+EOT
+        );
+        $this->requireAsset('javascript', 'vue');
+        if (!$this->app->make(LogProviderFactory::class)->hasRegisteredProviders()) {
+            $this->error->add(t('No payment method is providing log entries'));
+        }
+        $this->set('localization', $this->app->make(Localization::class));
+        $this->set('urlResolver', $this->app->make(ResolverManagerInterface::class));
+        $date = (string) $this->request->query->get('date', '');
+        $this->set('date', preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) ? $date : '');
+        $orderID = (int) $this->request->query->get('orderID', '0');
+        $this->set('orderID', $orderID > 0 ? $orderID : null);
+    }
+
+    public function fetch(): JsonResponse
+    {
+        if (!$this->token->validate('cs-pm-log')) {
+            throw new UserMessageException($this->token->getErrorMessage());
+        }
+        $logProviders = $this->app->make(LogProviderFactory::class)->getRegisteredProviders();
+        if ($logProviders === []) {
+            throw new UserMessageException(t('No payment method is providing log entries'));
+        }
+        $listBy = $this->request->request->get('listBy');
+        $result = [];
+        switch ($listBy) {
+            case 'date':
+                $date = $this->request->request->get('date');
+                if (!is_string($date) || !preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+                    throw new UserMessageException(t('Invalid parameter: %s', 'date'));
+                }
+                [$fromInclusive, $toExclusive] = $this->expandDate($date); 
+                foreach ($logProviders as $logProvider) {
+                    $result = array_merge($result, $logProvider->findByDate($fromInclusive, $toExclusive));
+                }
+                $sort = 1;
+                break;
+            case 'orderID':
+                $orderID = $this->request->request->get('orderID');
+                $orderID = is_numeric($orderID) ? (int) $orderID : 0;
+                if ($orderID <= 0) {
+                    throw new UserMessageException(t('Invalid parameter: %s', 'orderID'));
+                }
+                foreach ($logProviders as $logProvider) {
+                    $result = array_merge($result, $logProvider->findByOrderID($orderID));
+                }
+                $sort = 1;
+                break;
+            default:
+                throw new UserMessageException(t('Invalid parameter: %s', 'listBy'));
+        }
+        usort(
+            $result,
+            static function (LogEntry $a, LogEntry $b) use ($sort): int
+            {
+                if ($a->dateTime < $b->dateTime) {
+                    return -$sort;
+                }
+                if ($a->dateTime > $b->dateTime) {
+                    return $sort;
+                }
+                return 0;
+            }
+        );
+
+        return $this->app->make(ResponseFactoryInterface::class)->json($result);
+    }
+
+    private function expandDate(string $date): array
+    {
+        $dateService = $this->app->make(Date::class);
+        $systemTimezone = $dateService->getTimezone('system');
+        $userTimezone = $dateService->getTimezone('user');
+        $fromUserTime = DateTimeImmutable::createFromFormat('!Y-m-d', $date, $userTimezone);
+        $fromSystemTime = $fromUserTime->setTimezone($systemTimezone);
+        $toSystemTime = $fromSystemTime->add(new DateInterval('P1D'));
+
+        return [$fromSystemTime, $toSystemTime];
+    }
+}

--- a/single_pages/dashboard/store/orders.php
+++ b/single_pages/dashboard/store/orders.php
@@ -14,11 +14,19 @@ if (version_compare($version, '9.0', '<')) {
     $badgeClass = '';
 }
 
-?>
-
-<?php if ($controller->getAction() == 'order') { ?>
-
+if ($controller->getAction() == 'order') {
+    /**
+     * @var string $paymentReportUrl
+     */
+    ?>
     <div class="ccm-dashboard-header-buttons">
+        <?php
+        if ($paymentReportUrl !== '') {
+            ?>
+            <a href="<?= h($paymentReportUrl) ?>" class="btn btn-primary" target="_blank"><i class="fa fas fa-credit-card"></i> <?= t('Inspect Payment') ?></a>
+            <?php
+        }
+        ?>
         <a href="<?= Url::to('/dashboard/store/orders/printslip/' . $order->getOrderID()) ?>" class="btn btn-primary" target="_blank"><i class="fa fa-print"></i> <?= t("Print Order Slip") ?></a>
     </div>
 

--- a/single_pages/dashboard/store/reports/payments.php
+++ b/single_pages/dashboard/store/reports/payments.php
@@ -1,0 +1,299 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @var Concrete\Package\CommunityStore\Controller\SinglePage\Dashboard\Store\Reports\Payments $controller
+ * @var Concrete\Core\Form\Service\Form $form
+ * @var Concrete\Core\Html\Service\Html $html
+ * @var Concrete\Core\Application\Service\UserInterface $interface
+ * @var Concrete\Core\Validation\CSRF\Token $token
+ * @var Concrete\Core\Page\View\PageView $view
+ * @var Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface $urlResolver
+ * @var Concrete\Core\Localization\Localization $localization
+ * @var string $date
+ * @var int|null $orderID
+ */
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+?>
+<div id="cs-app" v-cloak>
+    <form v-on:submit.prevent="fetch">
+        <div class="row">
+            <div class="col-sm-4 col-xl-2">
+                <?= $form->label('cs-listBy', t('List by')) ?>
+                <?= $form->select(
+                    'cs-listBy',
+                    [
+                        'date' => t('Date'),
+                        'orderID' => t('Order ID'),
+                    ],
+                    '',
+                    [
+                        'v-bind:disabled' => 'busy',
+                        'v-model' => 'listBy',
+                    ]
+                ) ?>
+            </div>
+            <div class="col-sm-4 col-xl-2">
+                <div class="form-group" v-if="listBy === 'date'">
+                    <?= $form->label('cs-date', t('Date')) ?>
+                    <div class="input-group">
+                        <span class="input-group-btn">
+                            <button class="btn btn-default btn-secondary px-1" type="button" v-bind:disabled="busy" v-on:click.prevent="addDate(-1, true)">&larr;</button>
+                        </span>
+                        <?= $form->date(
+                            'cs-date',
+                            '',
+                            [
+                                'v-bind:max' => 'today',
+                                'v-model' => 'date',
+                                'v-bind:readonly' => 'busy',
+                            ]
+                        ) ?>
+                        <span class="input-group-btn">
+                            <button class="btn btn-default btn-secondary px-1" type="button" v-bind:disabled="busy || date === today" v-on:click.prevent="addDate(1, true)">&rarr;</button>
+                        </span>
+                    </div>
+                </div>
+                <div class="form-group" v-else-if="listBy === 'orderID'">
+                    <?= $form->label('cs-order', t('Order ID')) ?>
+                    <?= $form->number(
+                        'cs-order',
+                        '',
+                        [
+                            'v-model' => 'orderID',
+                            'v-bind:readonly' => 'busy',
+                            'min' => '1',
+                            'max' => (string) PHP_INT_MAX,
+                        ]
+                    ) ?>
+                </div>
+            </div>
+            <div class="col-sm-2  col-md-1 text-right text-end">
+                <div class="form-group">
+                    <?= $form->label('', '&nbsp;') ?><br />
+                    <button class="btn btn-primary" v-on:click.prevent="fetch" v-bind:disabled="busy">
+                        <?= t('Search') ?>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </form>
+    <div v-if="loaded">
+        <div v-if="entries.length === 0" class="alert alert-info">
+            <?= t('No entries found') ?>
+        </div>
+        <table v-else class="table table-striped table-hover">
+            <colgroup>
+                <col width="1" />
+                <col width="1" />
+            </colgroup>
+            <thead>
+                <tr>
+                    <th class="text-nowrap"><?= t('Order') ?></th>
+                    <th class="text-nowrap"><?= t('Date') ?></th>
+                    <th><?= t('Method') ?></th>
+                    <th><?= t('Type') ?></th>
+                    <th><?= t('Data') ?></th>
+                    <th><?= t('Error') ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr v-for="entry in entries">
+                    <td><a v-if="entry.orderUrl !== ''" target="_blank" v-bind:href="entry.orderUrl">{{ entry.orderID }}</a></td>
+                    <td class="text-nowrap">{{ entry.dateString }}</td>
+                    <td>{{ entry.paymentMethod }}</td>
+                    <td>{{ entry.type }}</td>
+                    <td>
+                        <button v-if="entry.data" class="btn btn-secondary btn-sm" v-on:click.prevent="viewEntryData(entry)"><?= t('View') ?></button>
+                    </td>
+                    <td>
+                        <div v-if="entry.error" class="text-danger" style="white-space: pre-wrap">{{ entry.error }}</div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <div class="d-none hide">
+        <div ref="cs-payment-data" title="<?= h(t('Data sent/received'))?>" class="ccm-ui">
+            <div>
+                <div v-if="entryForDataViewer !== null">
+                    <div v-if="typeof entryForDataViewer.data === 'string'" style="white-space: pre-wrap">{{ entryForDataViewer.data }}</div>
+                    <table v-else-if="entryForDataViewer.data instanceof Array" class="table table-striped table-hover table-sm table-condensed mb-0">
+                        <tbody>
+                            <tr v-for="row in entryForDataViewer.data">
+                                <th v-if="typeof row === 'string'" colspan="2" class="text-center">{{ row }}</th>
+                                <th v-if="typeof row !== 'string' && row[0]">{{ row[0] }}</th>
+                                <td v-if="typeof row !== 'string'" style="white-space: pre-wrap" v-bind:colspan="row[0] ? 1 : 2">{{ row[1] }}</td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+$(document).ready(() => {
+
+const DATETIME_FORMAT = new Intl.DateTimeFormat(
+    <?= json_encode(str_replace('_', '-', $localization->getLocale())) ?>,
+    {
+        dateStyle: 'short',
+        timeStyle: 'medium',
+    }
+);
+
+new Vue({
+    el: '#cs-app',
+    data() {
+        const today = new Date().toISOString().split('T')[0];
+        return {
+            busy: false,
+            today,
+            lastKnownGoodDate: today,
+            listBy: <?= json_encode($orderID === null ? 'date' : 'orderID') ?>,
+            date: <?= json_encode($date) ?> || today,
+            orderID: <?= json_encode($orderID) ?>,
+            entries: [],
+            loaded: false,
+            entryForDataViewer: null,
+        };
+    },
+    watch: {
+        date() {
+            if (this.buildDateObject() === null) {
+                this.date = this.lastKnownGoodDate;
+            } else {
+                this.lastKnownGoodDate = this.date;
+            }
+        },
+    },
+    mounted() {
+        this.fetch();
+    },
+    methods: {
+        buildDateObject() {
+            if (!this.date || !/^\d{4}-\d{2}-\d{2}$/.test(this.date) || this.date > this.today) {
+                return null;
+            }
+            const date = new Date(this.date);
+            return date && date.toString() !== 'Invalid Date' ? date : null;
+        },
+        addDate(deltaDays, doFetch) {
+            const date = this.buildDateObject() || new Date();
+            date.setHours(12);
+            date.setTime(date.getTime() + deltaDays * 24 * 60 * 60 * 1000);
+            let newDate = date.toISOString().split('T')[0];
+            if (newDate > this.today) {
+                newDate = this.today;
+            }
+            if (this.date === newDate) {
+                return;
+            }
+            this.date = newDate;
+            if (doFetch) {
+                this.fetch();
+            }
+        },
+        async fetch() {
+            if (this.busy) {
+                return;
+            }
+            this.busy = true;
+            this.updateUrl();
+            try {
+                const requestBody = new URLSearchParams();
+                requestBody.append(<?= json_encode($token::DEFAULT_TOKEN_NAME) ?>, <?= json_encode($token->generate('cs-pm-log')) ?>);
+                switch (this.listBy) {
+                    case 'date':
+                        if (!this.buildDateObject()) {
+                            throw new Error(<?= json_encode(t('Please specify the date')) ?>);
+                        }
+                        requestBody.append('date', this.date);
+                        break;
+                    case 'orderID':
+                        if (!this.orderID) {
+                            throw new Error(<?= json_encode(t('Please specify the order ID')) ?>);
+                        }
+                        requestBody.append('orderID', this.orderID);
+                        break;
+                    default:
+                        throw new Error(<?= json_encode(t('Please specify the search criteria')) ?>);
+                }
+                requestBody.append('listBy', this.listBy);
+                const response = await fetch(
+                    <?= json_encode((string) $controller->action('fetch')) ?>,
+                    {
+                        method: 'POST',
+                        headers: {
+                            'Content-Type': 'application/x-www-form-urlencoded',
+                            'X-Requested-With': 'XMLHttpRequest',
+                        },
+                        body: requestBody,
+                    }
+                );
+                const data = await response.json();
+                if (data.error) {
+                    throw new Error(data.error.message || data.error);
+                } else {
+                }
+                this.loaded = true;
+                this.entries.splice(0, this.entries.length);
+                data.forEach((entry) => this.entries.push(this.patchEntry(entry)));
+            } catch (e) {
+                window.alert(e.message || e);
+            }
+            this.busy = false;
+        },
+        patchEntry(entry) {
+            entry.date = new Date();
+            entry.date.setTime(entry.timestamp * 1000);
+            entry.dateString = DATETIME_FORMAT.format(entry.date);
+            delete entry.timestamp;
+            if (entry.orderID) {
+                entry.orderUrl = <?= json_encode((string) $urlResolver->resolve(['/dashboard/store/orders/order/', PHP_INT_MAX])) ?>.replace('<?= PHP_INT_MAX ?>', entry.orderID);
+            } else {
+                entry.orderUrl = '';
+            }
+            return entry;
+        },
+        viewEntryData(entry) {
+            this.entryForDataViewer = entry;
+            const $dialog = $(this.$refs['cs-payment-data']);
+            $dialog.find('>div')
+                .css({
+                    'max-height': Math.min(Math.max($(window).height() - 170, 200), 1500) + 'px',
+                    'overflow-y': 'auto',
+                })
+            ;
+            this.$nextTick(() => {
+                $dialog.dialog({
+                    modal: true,
+                    width: Math.min(Math.max($(window).width() - 20, 200), 1500),
+                });
+            });
+        },
+        updateUrl() {
+            let url = window.location.href.replace(/[#?].*$/, '');
+            switch (this.listBy) {
+                case 'date':
+                    if (this.buildDateObject() !== null) {
+                        url += '?date=' + this.date;
+                    }
+                    break;
+                case 'orderID':
+                    if (this.orderID) {
+                        url += '?orderID=' + this.orderID;
+                    }
+                    break;
+            }
+            window.history.replaceState(null, null, url);
+        },
+    },
+});
+
+});
+</script>

--- a/src/CommunityStore/Payment/LogEntry.php
+++ b/src/CommunityStore/Payment/LogEntry.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Concrete\Package\CommunityStore\Src\CommunityStore\Payment;
+
+use Concrete\Package\CommunityStore\Src\CommunityStore\Order\Order;
+use DateTimeInterface;
+use JsonSerializable;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/*readonly */ class LogEntry implements JsonSerializable
+{
+    public DateTimeInterface $dateTime;
+
+    public string $paymentMethod;
+
+    public string $type;
+
+    public ?Order $order;
+
+    /**
+     * @var string|array|null
+     *
+     * @example 'Text to be displayed'
+     *
+     * @example [
+     *     'Section 1',
+     *     ['Header 1.1', 'Value 1.1'],
+     *     ['Header 1.2', 'Value 1.2'],
+     *     'Section 2',
+     *     ['Header 2.1', 'Value 2.1'],
+     *     ['Header 2.2', 'Value 2.2'],
+     * ]
+     */
+    public $data;
+
+    public string $error;
+
+    /**
+     * @param string|array|null $data
+     */
+    public function __construct(
+        DateTimeInterface $dateTime,
+        string $paymentMethod,
+        string $type,
+        ?Order $order,
+        $data,
+        string $error = ''
+    )
+    {
+        $this->dateTime = $dateTime;
+        $this->paymentMethod = $paymentMethod;
+        $this->type = $type;
+        $this->order = $order;
+        $this->data = $data;
+        $this->error = $error;
+    }
+
+    public function jsonSerialize (): array
+    {
+        return [
+            'timestamp' => $this->dateTime->getTimestamp(),
+            'paymentMethod' => $this->paymentMethod,
+            'type' => $this->type,
+            'orderID' => $this->order === null ? null : $this->order->getOrderID(),
+            'data' => $this->data,
+            'error' => $this->error,
+        ];
+    }
+}

--- a/src/CommunityStore/Payment/LogProvider.php
+++ b/src/CommunityStore/Payment/LogProvider.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Package\CommunityStore\Src\CommunityStore\Payment;
+
+use DateTimeInterface;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+interface LogProvider
+{
+    /**
+     * Get the handle that uniquely identifies this log provider.
+     */
+    public function getHandle(): string;
+
+    /**
+     * Get the display name of this log provider.
+     */
+    public function getName(): string;
+
+    /**
+     * Find the log entries in the specified date/time range.
+     *
+     * @return \Concrete\Package\CommunityStore\Src\CommunityStore\Payment\LogEntry[]
+     */
+    public function findByDate(DateTimeInterface $fromInclusive, DateTimeInterface $toExclusive): array;
+
+    /**
+     * Find the log entries associated to a specific order.
+     *
+     * @return \Concrete\Package\CommunityStore\Src\CommunityStore\Payment\LogEntry[]
+     */
+    public function findByOrderID(int $orderID): array;
+}

--- a/src/CommunityStore/Payment/LogProviderFactory.php
+++ b/src/CommunityStore/Payment/LogProviderFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Package\CommunityStore\Src\CommunityStore\Payment;
+
+use RuntimeException;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+class LogProviderFactory
+{
+    /**
+     * @var \Concrete\Package\CommunityStore\Src\CommunityStore\Payment\LogProvider[]
+     */
+    private array $registeredProviders = [];
+
+    public function hasRegisteredProviders(): bool
+    {
+        return $this->registeredProviders !== [];
+    }
+
+    /**
+     * @return $this
+     */
+    public function registerProvider(LogProvider $provider): self
+    {
+        $handle = $provider->getHandle();
+        if (isset($this->registeredProviders[$handle])) {
+            throw new RuntimeException(t('Duplicated log provider handle: %s', $handle));
+        }
+        $this->registeredProviders[$handle] = $provider;
+
+        return $this;
+    }
+
+    /**
+     * @return \Concrete\Package\CommunityStore\Src\CommunityStore\Payment\LogProvider[]
+     */
+    public function getRegisteredProviders(): array
+    {
+        return array_values($this->registeredProviders);
+    }
+}

--- a/src/CommunityStore/Utilities/Installer.php
+++ b/src/CommunityStore/Utilities/Installer.php
@@ -446,6 +446,7 @@ class Installer
         self::installSinglePage('/dashboard/store/reports', $pkg);
         self::installSinglePage('/dashboard/store/reports/sales', $pkg);
         self::installSinglePage('/dashboard/store/reports/products', $pkg);
+        self::installSinglePage('/dashboard/store/reports/payments', $pkg);
         self::installSinglePage('/dashboard/store/multilingual', $pkg);
         self::installSinglePage('/dashboard/store/multilingual/products', $pkg);
         self::installSinglePage('/dashboard/store/multilingual/checkout', $pkg);


### PR DESCRIPTION
Close #877


PS: Payment methods that want to implement this new feature should:

1. Add/update the on_start method of the main package controller, so that we have:

```php
use Concrete\Package\CommunityStore\Src\CommunityStore\Payment\LogProviderFactory;

class Controller /* ... */
{
    public function on_start()
    {
        $this->app->extend(LogProviderFactory::class, function(LogProviderFactory $factory) {
            return $factory->registerProvider($this->app->make(MyLogProvider::class));
        });
    }
}
```

2. Create a log provider (`MyLogProvider` in the example above) that implements the methods of the `Concrete\Package\CommunityStore\Src\CommunityStore\Payment\LogProvider` interface introduced in this pull request.

