### PR TITLE
Use __CLASS__ instead of get_class()

### DIFF
--- a/src/CommunityStore/Discount/DiscountCode.php
+++ b/src/CommunityStore/Discount/DiscountCode.php
@@ -121,14 +121,14 @@ class DiscountCode
     {
         $em = dbORM::entityManager();
 
-        return $em->find(get_class(), $dcID);
+        return $em->find(__CLASS__, $dcID);
     }
 
     public static function getByCode($code)
     {
         $em = dbORM::entityManager();
 
-        return $em->getRepository(get_class())->findOneBy(['dcCode' => $code]);
+        return $em->getRepository(__CLASS__)->findOneBy(['dcCode' => $code]);
     }
 
     public static function add($discountRule, $code)

--- a/src/CommunityStore/Discount/DiscountRule.php
+++ b/src/CommunityStore/Discount/DiscountRule.php
@@ -541,7 +541,7 @@ class DiscountRule
     {
         $em = dbORM::entityManager();
 
-        return $em->find(get_class(), $drID);
+        return $em->find(__CLASS__, $drID);
     }
 
     public static function discountsWithCodesExist()

--- a/src/CommunityStore/Group/Group.php
+++ b/src/CommunityStore/Group/Group.php
@@ -69,7 +69,7 @@ class Group
     {
         $em = dbORM::entityManager();
 
-        return $em->getRepository(get_class())->findOneBy(['groupName' => $gName]);
+        return $em->getRepository(__CLASS__)->findOneBy(['groupName' => $gName]);
     }
 
     public static function add($groupName)

--- a/src/CommunityStore/Manufacturer/Manufacturer.php
+++ b/src/CommunityStore/Manufacturer/Manufacturer.php
@@ -127,7 +127,7 @@ class Manufacturer
     public static function getByID($mID)
     {
         $em = dbORM::entityManager();
-        return $em->find(get_class(), $mID);
+        return $em->find(__CLASS__, $mID);
     }
 
     public function save()

--- a/src/CommunityStore/Order/Order.php
+++ b/src/CommunityStore/Order/Order.php
@@ -546,14 +546,14 @@ class Order implements ObjectInterface
     {
         $em = dbORM::entityManager();
 
-        return $em->find(get_class(), $oID);
+        return $em->find(__CLASS__, $oID);
     }
 
     public function getCustomersMostRecentOrderByCID($cID)
     {
         $em = dbORM::entityManager();
 
-        return $em->getRepository(get_class())->findOneBy(['cID' => $cID]);
+        return $em->getRepository(__CLASS__)->findOneBy(['cID' => $cID]);
     }
 
     public function getAttributes()

--- a/src/CommunityStore/Order/OrderItem.php
+++ b/src/CommunityStore/Order/OrderItem.php
@@ -287,7 +287,7 @@ class OrderItem
     {
         $em = dbORM::entityManager();
 
-        return $em->find(get_class(), $oiID);
+        return $em->find(__CLASS__, $oiID);
     }
 
     public static function add($data, $oID, $tax = 0, $taxIncluded = 0, $taxName = '', $adjustRatio = 1)

--- a/src/CommunityStore/Order/OrderItemOption.php
+++ b/src/CommunityStore/Order/OrderItemOption.php
@@ -158,7 +158,7 @@ class OrderItemOption
     {
         $em = dbORM::entityManager();
 
-        return $em->find(get_class(), $oioID);
+        return $em->find(__CLASS__, $oioID);
     }
 
     public function save()

--- a/src/CommunityStore/Payment/Method.php
+++ b/src/CommunityStore/Payment/Method.php
@@ -162,7 +162,7 @@ class Method extends Controller
     public static function getByID($pmID)
     {
         $em = dbORM::entityManager();
-        $method = $em->find(get_class(), $pmID);
+        $method = $em->find(__CLASS__, $pmID);
 
         if ($method) {
             if ($method->setMethodController() === false) {
@@ -176,7 +176,7 @@ class Method extends Controller
     public static function getByHandle($pmHandle)
     {
         $em = dbORM::entityManager();
-        $method = $em->getRepository(get_class())->findOneBy(['pmHandle' => $pmHandle]);
+        $method = $em->getRepository(__CLASS__)->findOneBy(['pmHandle' => $pmHandle]);
 
         if ($method) {
             if ($method->setMethodController() === false) {
@@ -251,9 +251,9 @@ class Method extends Controller
     {
         $em = dbORM::entityManager();
         if ($enabled) {
-            $methods = $em->getRepository(get_class())->findBy(['pmEnabled' => 1], ['pmSortOrder' => 'ASC']);
+            $methods = $em->getRepository(__CLASS__)->findBy(['pmEnabled' => 1], ['pmSortOrder' => 'ASC']);
         } else {
-            $methods = $em->getRepository(get_class())->findBy([], ['pmSortOrder' => 'ASC']);
+            $methods = $em->getRepository(__CLASS__)->findBy([], ['pmSortOrder' => 'ASC']);
         }
         $goodMethods = [];
         foreach ($methods as $method) {

--- a/src/CommunityStore/Product/Product.php
+++ b/src/CommunityStore/Product/Product.php
@@ -1009,7 +1009,7 @@ class Product
     {
         $em = dbORM::entityManager();
 
-        return $em->find(get_class(), $pID);
+        return $em->find(__CLASS__, $pID);
     }
 
 	/**
@@ -1019,7 +1019,7 @@ class Product
     {
         $em = dbORM::entityManager();
 
-        return $em->getRepository(get_class())->findOneBy(['pSKU' => $pSKU]);
+        return $em->getRepository(__CLASS__)->findOneBy(['pSKU' => $pSKU]);
     }
 
 	/**
@@ -1029,7 +1029,7 @@ class Product
     {
         $em = dbORM::entityManager();
 
-        $product =  $em->getRepository(get_class())->findOneBy(['cID' => $cID]);
+        $product =  $em->getRepository(__CLASS__)->findOneBy(['cID' => $cID]);
 
         // if product not found, look for it via multilingual related page
         if ($allLocales && !$product) {

--- a/src/CommunityStore/Product/ProductFile.php
+++ b/src/CommunityStore/Product/ProductFile.php
@@ -70,14 +70,14 @@ class ProductFile
     {
         $em = dbORM::entityManager();
 
-        return $em->find(get_class(), $id);
+        return $em->find(__CLASS__, $id);
     }
 
     public static function getFilesForProduct(Product $product)
     {
         $em = dbORM::entityManager();
 
-        return $em->getRepository(get_class())->findBy(['pID' => $product->getID()]);
+        return $em->getRepository(__CLASS__)->findBy(['pID' => $product->getID()]);
     }
 
     public static function getFileObjectsForProduct(Product $product)

--- a/src/CommunityStore/Product/ProductGroup.php
+++ b/src/CommunityStore/Product/ProductGroup.php
@@ -109,13 +109,13 @@ class ProductGroup
     {
         $em = dbORM::entityManager();
 
-        return $em->find(get_class(), $pgID);
+        return $em->find(__CLASS__, $pgID);
     }
 
     public static function getGroupsForProduct(Product $product)
     {
         $em = dbORM::entityManager();
-        $productGroups = $em->getRepository(get_class())->findBy(['pID' => $product->getID()]);
+        $productGroups = $em->getRepository(__CLASS__)->findBy(['pID' => $product->getID()]);
         $groups = [];
         if (count($productGroups)) {
             foreach ($productGroups as $productGroup) {
@@ -131,7 +131,7 @@ class ProductGroup
         $em = dbORM::entityManager();
         $gID = $group->getGroupID();
 
-        $productGroup = $em->getRepository(get_class())->findBy(['pID' => $product->getID(), 'gID' => $gID]);
+        $productGroup = $em->getRepository(__CLASS__)->findBy(['pID' => $product->getID(), 'gID' => $gID]);
         if (count($productGroup)) {
             return true;
         }
@@ -185,7 +185,7 @@ class ProductGroup
     public static function removeGroupsForProduct(Product $product)
     {
         $em = dbORM::entityManager();
-        $groups = $em->getRepository(get_class())->findBy(['pID' => $product->getID()]);
+        $groups = $em->getRepository(__CLASS__)->findBy(['pID' => $product->getID()]);
         foreach ($groups as $productGroup) {
             $productGroup->delete();
         }
@@ -194,7 +194,7 @@ class ProductGroup
     public static function removeProductsForGroup(StoreGroup $group)
     {
         $em = dbORM::entityManager();
-        $groups = $em->getRepository(get_class())->findBy(['gID' => $group->getID()]);
+        $groups = $em->getRepository(__CLASS__)->findBy(['gID' => $group->getID()]);
         foreach ($groups as $productGroup) {
             $productGroup->delete();
         }

--- a/src/CommunityStore/Product/ProductImage.php
+++ b/src/CommunityStore/Product/ProductImage.php
@@ -83,14 +83,14 @@ class ProductImage
     {
         $em = dbORM::entityManager();
 
-        return $em->find(get_class(), $piID);
+        return $em->find(__CLASS__, $piID);
     }
 
     public static function getImagesForProduct(Product $product)
     {
         $em = dbORM::entityManager();
 
-        return $em->getRepository(get_class())->findBy(['pID' => $product->getID()], ['piSort' => 'ASC']);
+        return $em->getRepository(__CLASS__)->findBy(['pID' => $product->getID()], ['piSort' => 'ASC']);
     }
 
     /**

--- a/src/CommunityStore/Product/ProductLocation.php
+++ b/src/CommunityStore/Product/ProductLocation.php
@@ -103,21 +103,21 @@ class ProductLocation
     {
         $em = dbORM::entityManager();
 
-        return $em->find(get_class(), $cID);
+        return $em->find(__CLASS__, $cID);
     }
 
     public static function getLocationsForProduct(Product $product)
     {
         $em = dbORM::entityManager();
 
-        return $em->getRepository(get_class())->findBy(['pID' => $product->getID()], ['productSortOrder' => 'asc']);
+        return $em->getRepository(__CLASS__)->findBy(['pID' => $product->getID()], ['productSortOrder' => 'asc']);
     }
 
     public static function getProductsForLocation($cID)
     {
         $em = dbORM::entityManager();
 
-        return $em->getRepository(get_class())->findBy(['cID' => $cID], ['categorySortOrder' => 'asc']);
+        return $em->getRepository(__CLASS__)->findBy(['cID' => $cID], ['categorySortOrder' => 'asc']);
     }
 
     public static function addLocationsForProduct(array $locations, Product $product)

--- a/src/CommunityStore/Product/ProductOption/ProductOption.php
+++ b/src/CommunityStore/Product/ProductOption/ProductOption.php
@@ -190,14 +190,14 @@ class ProductOption
     {
         $em = dbORM::entityManager();
 
-        return $em->find(get_class(), $id);
+        return $em->find(__CLASS__, $id);
     }
 
     public static function getOptionsForProduct(Product $product)
     {
         $em = dbORM::entityManager();
 
-        return $em->getRepository(get_class())->findBy(['pID' => $product->getID()]);
+        return $em->getRepository(__CLASS__)->findBy(['pID' => $product->getID()]);
     }
 
     public static function removeOptionsForProduct(Product $product, $excluding = [])

--- a/src/CommunityStore/Product/ProductOption/ProductOptionItem.php
+++ b/src/CommunityStore/Product/ProductOption/ProductOptionItem.php
@@ -177,14 +177,14 @@ class ProductOptionItem
     {
         $em = dbORM::entityManager();
 
-        return $em->find(get_class(), $id);
+        return $em->find(__CLASS__, $id);
     }
 
     public static function getOptionItemsForProductOption(ProductOption $po)
     {
         $em = dbORM::entityManager();
 
-        return $em->getRepository(get_class())->findBy(['poID' => $po->getID()], ['poiSort' => 'asc']);
+        return $em->getRepository(__CLASS__)->findBy(['poID' => $po->getID()], ['poiSort' => 'asc']);
     }
 
     public static function removeOptionItemsForProduct(Product $product, $excluding = [])

--- a/src/CommunityStore/Product/ProductRelated.php
+++ b/src/CommunityStore/Product/ProductRelated.php
@@ -93,14 +93,14 @@ class ProductRelated
     {
         $em = dbORM::entityManager();
 
-        return $em->find(get_class(), $cID);
+        return $em->find(__CLASS__, $cID);
     }
 
     public static function getRelatedProducts(Product $product)
     {
         $em = dbORM::entityManager();
 
-        return $em->getRepository(get_class())->findBy(['pID' => $product->getID()]);
+        return $em->getRepository(__CLASS__)->findBy(['pID' => $product->getID()]);
     }
 
     public static function addRelatedProducts(array $products, Product $product)

--- a/src/CommunityStore/Product/ProductVariation/ProductVariation.php
+++ b/src/CommunityStore/Product/ProductVariation/ProductVariation.php
@@ -637,7 +637,7 @@ class ProductVariation
     {
         $em = dbORM::entityManager();
 
-        return $em->find(get_class(), $pvID);
+        return $em->find(__CLASS__, $pvID);
     }
 
     /**
@@ -647,7 +647,7 @@ class ProductVariation
     {
         $em = dbORM::entityManager();
 
-        return $em->getRepository(get_class())->findOneBy(['pvSKU' => $pvSKU]);
+        return $em->getRepository(__CLASS__)->findOneBy(['pvSKU' => $pvSKU]);
     }
 
     public static function add($product, $data, $persistonly = false)

--- a/src/CommunityStore/Tax/TaxClass.php
+++ b/src/CommunityStore/Tax/TaxClass.php
@@ -132,14 +132,14 @@ class TaxClass
     {
         $em = dbORM::entityManager();
 
-        return $em->find(get_class(), $tcID);
+        return $em->find(__CLASS__, $tcID);
     }
 
     public static function getByHandle($taxClassHandle)
     {
         $em = dbORM::entityManager();
 
-        return $em->getRepository(get_class())->findOneBy(['taxClassHandle' => $taxClassHandle]);
+        return $em->getRepository(__CLASS__)->findOneBy(['taxClassHandle' => $taxClassHandle]);
     }
 
     public static function getTaxClasses()

--- a/src/CommunityStore/Tax/TaxRate.php
+++ b/src/CommunityStore/Tax/TaxRate.php
@@ -179,7 +179,7 @@ class TaxRate
     {
         $em = dbORM::entityManager();
 
-        return $em->find(get_class(), $trID);
+        return $em->find(__CLASS__, $trID);
     }
 
     public function isVatNumberEligible()


### PR DESCRIPTION
Calling `get_class()` without arguments is deprecated since PHP 8.3.
We can simply use `__CLASS__` instead, or even `self::class` (but not `static::class` which may result in a different value).

https://3v4l.org/ogXmu demonstrates everthing.

Just a side note: using constants instead of functions is faster (calling functions implies some overhead: pushing the stack, execute some code, and then popping the stack back).