### PR TITLE
Added a config option to disable freshly created variants from administration panel

### DIFF
--- a/config/products.php
+++ b/config/products.php
@@ -17,4 +17,6 @@ return [
             'updateOpenGraph' >= false,
         ],
     ],
+
+    'newVariantDisable' => false,
 ];

--- a/controllers/single_page/dashboard/store/settings.php
+++ b/controllers/single_page/dashboard/store/settings.php
@@ -236,7 +236,7 @@ class Settings extends DashboardPageController
                 Config::save('community_store::products.hideWeight', !empty($args['hideWeight']));
                 Config::save('community_store::products.hideBarcode', !empty($args['hideBarcode']));
                 
-                Config::save('community_store::products.newVariantDisable', boolval($args['newVariantDisable']));
+                Config::save('community_store::products.newVariantDisable', !empty($args['newVariantDisable']));
 
                 Config::save('community_store.hideVariationPrices', isset($args['hideVariationPrices']) ?? false);
                 Config::save('community_store.hideVariationShippingFields', isset($args['hideVariationShippingFields']) ?? false);

--- a/controllers/single_page/dashboard/store/settings.php
+++ b/controllers/single_page/dashboard/store/settings.php
@@ -235,6 +235,9 @@ class Settings extends DashboardPageController
                 Config::save('community_store::products.hideSize', !empty($args['hideSize']));
                 Config::save('community_store::products.hideWeight', !empty($args['hideWeight']));
                 Config::save('community_store::products.hideBarcode', !empty($args['hideBarcode']));
+                
+                Config::save('community_store::products.newVariantDisable', boolval($args['newVariantDisable']));
+
                 Config::save('community_store.hideVariationPrices', isset($args['hideVariationPrices']) ?? false);
                 Config::save('community_store.hideVariationShippingFields', isset($args['hideVariationShippingFields']) ?? false);
                 Config::save('community_store.hideSalePrice',  isset($args['hideSalePrice']) ?? false);

--- a/single_pages/dashboard/store/products.php
+++ b/single_pages/dashboard/store/products.php
@@ -1,12 +1,14 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
 
+use Concrete\Controller\Element\Attribute\Form;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Support\Facade\Config;
 use Concrete\Core\Support\Facade\Url;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Product\Product;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Product\ProductVariation\ProductVariation;
 use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\AutoUpdaterQuantitiesFromVariations;
+use Concrete\Core\Support\Facade\Log;
 
 /**
  * @var Concrete\Core\Application\Service\FileManager $al
@@ -1550,7 +1552,11 @@ if (version_compare($version, '9.0', '<')) {
 
                                                 <div class="form-group pull-right mt-2">
 													<?= $form->label('pvDisabled[' . $varid . ']', t('Disabled')); ?>
-													<?= $form->checkbox('pvDisabled[' . $varid . ']', 1, $variation ? $variation->getVariationDisabled() : false, ['data-combokey'=>$comboKey, 'class'=>'optionDisabled']) ?>
+                                                    <?php
+                                                    $newVariantDisable = Config::get("community_store::products.newVariantDisable");
+                                                    Log::addInfo('newVariantDisable: ' . $newVariantDisable);
+                                                    ?>
+													<?= $form->checkbox('pvDisabled[' . $varid . ']', 1, $variation ? $variation->getVariationDisabled() : $newVariantDisable, ['data-combokey'=>$comboKey, 'class'=>'optionDisabled']) ?>
                                                 </div>
 
                                             </div>

--- a/single_pages/dashboard/store/settings.php
+++ b/single_pages/dashboard/store/settings.php
@@ -498,6 +498,18 @@ use Concrete\Package\CommunityStore\Src\CommunityStore\Utilities\Image;
                 <div class="small text-muted"><?= $automaticProductQuantitiesMessage ?></div>
             </div>
 
+            <div class="form-group">
+                <label><?= t('Disable new variants by default') ?></label>
+                <div class="checkbox form-check">
+                    <?php
+                    $newVariantDisable = Config::get("community_store::products.newVariantDisable") ? '1' : '0';
+                    ?>
+                    <div class="radio"><label><?= $form->radio('newVariantDisable', '1', $newVariantDisable) ?><?= t('Yes, disable new variants at their creation') ?></label></div>
+                    <div class="radio"><label><?= $form->radio('newVariantDisable', '0', $newVariantDisable) ?><?= t('No, do not disable new variants when they are created') ?></label></div>
+                </div>
+                <div class="small text-muted"><?= t("Disabling new variants when they are created can be relevant if not all combinations of options are not meant to be available") ?></div>
+            </div>
+
         </div>
 
         <!-- #settings-product-images -->

--- a/src/CommunityStore/Product/ProductVariation/ProductVariation.php
+++ b/src/CommunityStore/Product/ProductVariation/ProductVariation.php
@@ -549,7 +549,7 @@ class ProductVariation
                         'pvHeight' => '',
                         'pvLength' => '',
                         'pvSort' => $sort,
-                        'pvDisabled' => 0,
+                        'pvDisabled' => Config::get('community_store::products.newVariantDisable'),
                          true, ]
                     );
 
@@ -669,6 +669,7 @@ class ProductVariation
         $variation->setVariationWidth($data['pvWeight']);
         $variation->setVariationPackageData(isset($data['pvPackageData']) ? $data['pvPackageData'] : '');
         $variation->setVariationSort($data['pvSort']);
+        $variation->setVariationDisabled(isset($data['pvDisabled']) ? $data['pvDisabled'] : Config::get('community_store::products.newVariantDisable'));
         $product->getVariations()->add($variation);
         $variation->save($persistonly);
 


### PR DESCRIPTION
Actually, the products administration interface creates all possible OptionItems combinations for product variations. It may be annoying for some use cases, especially if not all possible variants are meant to be available. It is the case at my company where we imported massive amounts of products and variations from Prestashop to Community Store: when we used the panel to manage a product and saved, new variants were created silently.

This new option partially solves this issue by disabling by default all variants that do not already exist,