### PR TITLE
use the SORT_NATURAL flag for sorting attributes

### DIFF
--- a/blocks/community_product_filter/controller.php
+++ b/blocks/community_product_filter/controller.php
@@ -304,7 +304,7 @@ class Controller extends BlockController
                 }
 
                 foreach ($attributemapping as $attrhandle => $values) {
-                    ksort($attributemapping[$attrhandle]);
+                    ksort($attributemapping[$attrhandle], SORT_NATURAL);
                 }
             }
 


### PR DESCRIPTION
this allows numeric values to show up their expected order. Previously an attribute with various numeric values would show up in the following order:

0-50
101-250
250+
51-100

After the change they will show up as:
0-50
51-100
101-150
250+