### PR TITLE
When filtering by on sale, observe product sale date parameters

### DIFF
--- a/src/CommunityStore/Product/ProductList.php
+++ b/src/CommunityStore/Product/ProductList.php
@@ -401,6 +401,12 @@ class ProductList extends AttributedItemList implements PaginationProviderInterf
         }
         if ($this->saleOnly) {
             $query->andWhere("pSalePrice is not null");
+
+            $query->andWhere($query->expr()->or('pSaleStart IS NULL',
+		        $query->expr()->lte('pSaleStart', $query->createNamedParameter(date('Y-m-d H:i:s')))));
+
+	        $query->andWhere($query->expr()->or('pSaleEnd IS NULL',
+		        $query->expr()->gte('pSaleEnd', $query->createNamedParameter(date('Y-m-d H:i:s')))));
         }
         if (!$this->showOutOfStock) {
             $query->andWhere("pQty > 0 OR pQtyUnlim = 1");


### PR DESCRIPTION
When filtering the products list by on sale, it  was looking at a not null sale price only, and ignoring the date range set in the dashboard.