### PR TITLE
Update visibility of variables to protected, fixing #898

### DIFF
--- a/src/CommunityStore/Order/OrderList.php
+++ b/src/CommunityStore/Order/OrderList.php
@@ -22,72 +22,72 @@ class OrderList extends AttributedItemList implements PaginationProviderInterfac
     /**
      * @var int
      */
-    private $limit = 0;
+    protected $limit = 0;
 
     /**
      * @var string
      */
-    private $search = '';
+    protected $search = '';
 
     /**
      * @var string
      */
-    private $status = '';
+    protected $status = '';
 
     /**
      * @var int|null
      */
-    private $paymentMethod = null;
+    protected $paymentMethod = null;
 
     /**
      * @var string
      */
-    private $paymentStatus = '';
+    protected $paymentStatus = '';
 
     /**
      * @var bool|null
      */
-    private $externalPaymentRequested = false;
+    protected $externalPaymentRequested = false;
 
     /**
      * @var string
      */
-    private $fromDate = '';
+    protected $fromDate = '';
 
     /**
      * @var string
      */
-    private $toDate = '';
+    protected $toDate = '';
 
     /**
      * @var bool|null
      */
-    private $paid = null;
+    protected $paid = null;
 
     /**
      * @var bool|null
      */
-    private $cancelled = null;
+    protected $cancelled = null;
 
     /**
      * @var bool|null
      */
-    private $refunded = null;
+    protected $refunded = null;
 
     /**
      * @var bool|null
      */
-    private $shippable = null;
+    protected $shippable = null;
 
     /**
      * @var int|null
      */
-    private $cID = null;
+    protected $cID = null;
 
     /**
      * @var int[]
      */
-    private $orderIDs = [];
+    protected $orderIDs = [];
 
     /**
      * @param int $limit


### PR DESCRIPTION
The community store order history package extends the orderlist class, which since PR #833 has had private access to its variables, which means they are no longer visible to the extending class and thus all orders for everyone are shown to all users.

See https://github.com/JeRoNZ/community_store_order_history/issues/6
https://github.com/concretecms-community-store/community_store/issues/898