### PR TITLE
When executing communityStore.addToCart check for a defined function

### DIFF
--- a/js/communityStore.js
+++ b/js/communityStore.js
@@ -85,6 +85,13 @@ var communityStore = {
     },
 
     addToCart: function(form) {
+        if (typeof onBeforeAddToCart === 'function'){
+            var ret = onBeforeAddToCart(form);
+            if (ret === false) {
+                return false;
+            }
+        }
+
         var valid = true;
         var priceinput = $(form).find('.store-product-customer-price-entry-field');
 


### PR DESCRIPTION
onBeforeAddToCart and execute that first, returning without adding if the function returns boolean false. The function may modify the passed form argument, pushing values into a hidden form order attribute etc.

The reason I did this is that I needed to use the cart for an event booking system, where the user can choose from a list of available dates, or all dates with a correspondingly variable price. I also have to check that there are no more than 100 users registered for a particular day, and that gets tricky when they could be picking one day or all days, so some rather
tortuous back end logic needs to happen first)

I couldn't get the additional event listeners to play nicely, so I figured the tidiest solution here was to make addToCart check for the existence of a custom function (defined in the view) and execute that first, bailing out if it returns false.