### PR TITLE
use concrete method to load set attributes

### DIFF
--- a/src/Concrete/Entity/Attribute/Key/StoreOrderKey.php
+++ b/src/Concrete/Entity/Attribute/Key/StoreOrderKey.php
@@ -60,18 +60,14 @@ class StoreOrderKey extends Key
         }
 
         $akList = [];
-        $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
-        $orderCategory = $app->make('Concrete\Package\CommunityStore\Attribute\Category\OrderCategory');
-        $attlist = $orderCategory->getList();
+        $attlist = $set->getAttributeKeys();
 
 
         foreach ($attlist as $ak) {
-            if (in_array($set, $ak->getAttributeSets())) {
-                $attributeGroups = $ak->getAttributeUserGroups();
+            $attributeGroups = $ak->getAttributeUserGroups();
 
-                if (is_null($user) || (empty($attributeGroups) || array_intersect($attributeGroups, $uGroupIDs))) {
-                    $akList[] = $ak;
-                }
+            if (is_null($user) || (empty($attributeGroups) || array_intersect($attributeGroups, $uGroupIDs))) {
+                $akList[] = $ak;
             }
         }
 


### PR DESCRIPTION
this respects the order of the attributes from their set on the checkout page

I'm not sure if I am missing additional context in how the attributes are currently being loaded, but this PR would load them directly from the set instead of loading all order attributes and then checking if they are in the relevant set. Using this method loads them in the anticipated order on the checkout page.

closes #908 