### PR TITLE
Make geolocateCountry a protected function

### DIFF
--- a/controllers/single_page/checkout.php
+++ b/controllers/single_page/checkout.php
@@ -789,7 +789,7 @@ class Checkout extends PageController
      *
      * @return string empty string in case of errors.
      */
-    private function geolocateCountry()
+    protected function geolocateCountry()
     {
         if (!class_exists(GeolocationResult::class)) {
             return '';


### PR DESCRIPTION
rather than private so that it doesn't need to be included in a controller override.

I need to override the controller to introduce a different address search function (via NZ Post API FYI) and I have to include geolocateCountry too since it's private and can't be accessed from the view method, which is the only bit I want to mess with, and hence I'm extending the package version.